### PR TITLE
Group routine Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,25 +5,33 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      github-actions:
+      github-actions-minor-and-patch:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "monthly"
     groups:
-      npm-packages:
+      npm-minor-and-patch:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "gomod"
     directory: "/wasm"
     schedule:
       interval: "monthly"
     groups:
-      go-packages:
+      go-minor-and-patch:
         patterns:
           - "*"
-
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Groups minor and patch updates for npm, Go modules, and GitHub Actions while keeping major upgrades separate.