### PR TITLE
Bump Go version to 1.26

### DIFF
--- a/wasm/go.mod
+++ b/wasm/go.mod
@@ -1,6 +1,6 @@
 module github.com/yuxincs/goggle
 
-go 1.24.0
+go 1.26
 
 require golang.org/x/tools v0.42.0
 


### PR DESCRIPTION
Updates the WebAssembly module to target the latest stable Go major version. The WebAssembly build passes with Go 1.26.5.