### PR TITLE
Return structured analysis results

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,12 @@ import { CFGViewer } from "./viewers/CFGViewer.tsx";
 import { SSAViewer } from "./viewers/SSAViewer.tsx";
 import { SourceEditor } from "./viewers/SourceEditor.tsx";
 import { Title } from "./title/Title.tsx";
+import {
+  AnalysisResult,
+  ASTNode,
+  CFGFunction,
+  SSAFunction,
+} from "./analysis.ts";
 
 // We store the Go source and the last cursor position in local storage such that users will not lose their input.
 const defaultCode = `// You can edit this code!
@@ -41,9 +47,9 @@ export const App = () => {
   const [rightRowSplit, setRightRowSplit] = useState(50);
   const workspaceRef = useRef<HTMLElement>(null);
 
-  const [ast, setAST] = useState<string>("");
-  const [cfgs, setCFGs] = useState<string>("");
-  const [ssa, setSSA] = useState<string>("");
+  const [ast, setAST] = useState<ASTNode | string | null>(null);
+  const [cfgs, setCFGs] = useState<CFGFunction[] | string | null>(null);
+  const [ssa, setSSA] = useState<SSAFunction[] | string | null>(null);
 
   // Start Go WebAssembly such that the parse function is available in global this.
   // Then, load the source and position from local storage and set then.
@@ -89,7 +95,7 @@ export const App = () => {
       return;
     }
 
-    const body = JSON.parse(result.body);
+    const body = JSON.parse(result.body) as AnalysisResult;
     setAST(body.ast);
     setCFGs(body.cfgs);
     setSSA(body.ssa);
@@ -97,7 +103,7 @@ export const App = () => {
 
   const handleSrcPosChange = (pos: IPosition) => setSrcPos(pos);
 
-  const hasError = ast.startsWith("ERROR:");
+  const hasError = typeof ast === "string" && ast.startsWith("ERROR:");
 
   type Splitter = "column" | "leftRow" | "rightRow";
 

--- a/src/analysis.ts
+++ b/src/analysis.ts
@@ -1,0 +1,198 @@
+export interface SourcePosition {
+  offset: number;
+  line: number;
+  column: number;
+}
+
+export interface SourceRange {
+  start: SourcePosition;
+  end: SourcePosition;
+}
+
+export interface ASTChild {
+  field: string;
+  index?: number;
+  node: ASTNode;
+}
+
+export interface ASTNode {
+  type: string;
+  range: SourceRange;
+  properties?: Record<string, string>;
+  children?: ASTChild[];
+}
+
+export interface SyntaxNode {
+  type: string;
+  range: SourceRange;
+  source: string;
+}
+
+export interface CFGBlock {
+  index: number;
+  kind: string;
+  live: boolean;
+  statement?: SyntaxNode;
+  nodes: SyntaxNode[];
+  successors: number[];
+}
+
+export interface CFGFunction {
+  name: string;
+  range: SourceRange;
+  noReturn: boolean;
+  blocks: CFGBlock[];
+}
+
+export interface SSAValue {
+  name: string;
+  type: string;
+  text: string;
+}
+
+export interface SSAInstruction {
+  index: number;
+  opcode: string;
+  text: string;
+  position?: SourcePosition;
+  result?: SSAValue;
+  operands: SSAValue[];
+}
+
+export interface SSABlock {
+  index: number;
+  comment?: string;
+  predecessors: number[];
+  successors: number[];
+  instructions: SSAInstruction[];
+}
+
+export interface SSAFunction {
+  name: string;
+  signature: string;
+  position: SourcePosition;
+  parameters: SSAValue[];
+  blocks: SSABlock[];
+}
+
+export interface AnalysisResult {
+  ast: ASTNode;
+  cfgs: CFGFunction[];
+  ssa: SSAFunction[];
+}
+
+const formatPosition = (position: SourcePosition) =>
+  `${position.line}:${position.column}`;
+
+const formatRange = (range: SourceRange) =>
+  `${formatPosition(range.start)}-${formatPosition(range.end)}`;
+
+const indentMultiline = (value: string, indentation: string) =>
+  value.split("\n").join(`\n${indentation}`);
+
+export const formatAST = (root: ASTNode): string => {
+  const lines: string[] = [];
+
+  const visit = (node: ASTNode, depth: number, label?: string) => {
+    const indentation = "  ".repeat(depth);
+    const properties = Object.entries(node.properties ?? {})
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, value]) => `${key}=${JSON.stringify(value)}`)
+      .join(" ");
+    const prefix = label === undefined ? "" : `${label}: `;
+    lines.push(
+      `${indentation}${prefix}${node.type} [${formatRange(node.range)}]${properties === "" ? "" : ` ${properties}`}`,
+    );
+
+    for (const child of node.children ?? []) {
+      const childLabel = child.index === undefined
+        ? child.field
+        : `${child.field}[${child.index}]`;
+      visit(child.node, depth + 1, childLabel);
+    }
+  };
+
+  visit(root, 0);
+  return lines.join("\n");
+};
+
+export const formatCFGs = (functions: CFGFunction[]): string => {
+  if (functions.length === 0) {
+    return "CFG unavailable, try adding function declarations to the source";
+  }
+
+  return functions.map((fn) => {
+    const lines = [
+      `func ${fn.name} [${formatRange(fn.range)}]${fn.noReturn ? " (no return)" : ""}`,
+    ];
+
+    for (const block of fn.blocks) {
+      lines.push(
+        "",
+        `block ${block.index} (${block.kind})${block.live ? "" : " [unreachable]"}`,
+      );
+      if (block.statement !== undefined) {
+        lines.push(
+          `  control: ${block.statement.type} [${formatRange(block.statement.range)}]`,
+        );
+      }
+      for (const node of block.nodes) {
+        lines.push(
+          `  ${node.type} [${formatRange(node.range)}] ${indentMultiline(node.source, "  ")}`,
+        );
+      }
+      lines.push(
+        `  successors: ${block.successors.length === 0 ? "none" : block.successors.join(", ")}`,
+      );
+    }
+
+    return lines.join("\n");
+  }).join("\n\n");
+};
+
+export const formatSSA = (functions: SSAFunction[]): string => {
+  if (functions.length === 0) {
+    return "SSA unavailable, try adding function declarations to the source";
+  }
+
+  return functions.map((fn) => {
+    const signature = fn.signature.startsWith("func")
+      ? fn.signature.slice("func".length)
+      : ` ${fn.signature}`;
+    const lines = [
+      `func ${fn.name}${signature} [${formatPosition(fn.position)}]`,
+    ];
+
+    for (const block of fn.blocks) {
+      const comment = block.comment === "" || block.comment === undefined
+        ? ""
+        : ` (${block.comment})`;
+      const predecessors = block.predecessors.length === 0
+        ? "none"
+        : block.predecessors.join(", ");
+      const successors = block.successors.length === 0
+        ? "none"
+        : block.successors.join(", ");
+      lines.push(
+        "",
+        `block ${block.index}${comment}  predecessors: ${predecessors}  successors: ${successors}`,
+      );
+
+      for (const instruction of block.instructions) {
+        const result = instruction.result?.name === undefined ||
+            instruction.result.name === ""
+          ? ""
+          : `${instruction.result.name} = `;
+        const resultType = instruction.result?.type === undefined ||
+            instruction.result.type === ""
+          ? ""
+          : `  // ${instruction.result.type}`;
+        lines.push(
+          `  ${instruction.index}: ${result}${instruction.text}${resultType}`,
+        );
+      }
+    }
+
+    return lines.join("\n");
+  }).join("\n\n");
+};

--- a/src/viewers/ASTViewer.tsx
+++ b/src/viewers/ASTViewer.tsx
@@ -3,20 +3,27 @@ import React from "react";
 import { IPosition } from "monaco-editor";
 import { ViewerTitle } from "./ViewerTitle.tsx";
 import { VIEWER_TITLE_HEIGHT } from "../constants.ts";
+import { ASTNode, formatAST } from "../analysis.ts";
 
 interface ASTViewerProps {
   src: string;
   srcPos: IPosition;
-  ast: string;
+  ast: ASTNode | string | null;
   theme: "light" | "dark";
 }
 
 export const ASTViewer: React.FC<ASTViewerProps> = (props: ASTViewerProps) => {
+  const content = props.ast === null
+    ? "AST unavailable"
+    : typeof props.ast === "string"
+      ? props.ast
+      : formatAST(props.ast);
+
   return (
     <>
       <ViewerTitle sx={{ height: VIEWER_TITLE_HEIGHT }}>AST</ViewerTitle>
       <CodeViewer
-        content={props.ast}
+        content={content}
         line={props.srcPos.lineNumber}
         readOnly={true}
         theme={props.theme}

--- a/src/viewers/CFGViewer.tsx
+++ b/src/viewers/CFGViewer.tsx
@@ -3,33 +3,24 @@ import React from "react";
 import { IPosition } from "monaco-editor";
 import { ViewerTitle } from "./ViewerTitle.tsx";
 import { VIEWER_TITLE_HEIGHT } from "../constants.ts";
-
-interface CFG {
-  name: string;
-  repr: string;
-  dot: string;
-}
+import { CFGFunction, formatCFGs } from "../analysis.ts";
 
 interface CFGViewerProps {
   src: string;
   srcPos: IPosition;
-  cfgs: CFG[] | string | undefined | null;
+  cfgs: CFGFunction[] | string | null;
   theme: "light" | "dark";
 }
 
 export const CFGViewer: React.FC<CFGViewerProps> = (props: CFGViewerProps) => {
   let content: string;
 
-  if (props.cfgs === undefined || props.cfgs === null) {
+  if (props.cfgs === null) {
     content = `CFG unavailable, try adding function declarations to the source`;
   } else if (typeof props.cfgs === "string") {
     content = props.cfgs;
   } else {
-    const parts = [];
-    for (const cfg of props.cfgs) {
-      parts.push(`${cfg.name}\n${cfg.repr}`);
-    }
-    content = parts.join("\n");
+    content = formatCFGs(props.cfgs);
   }
 
   return (

--- a/src/viewers/SSAViewer.tsx
+++ b/src/viewers/SSAViewer.tsx
@@ -3,21 +3,24 @@ import React from "react";
 import { IPosition } from "monaco-editor";
 import { ViewerTitle } from "./ViewerTitle.tsx";
 import { VIEWER_TITLE_HEIGHT } from "../constants.ts";
+import { formatSSA, SSAFunction } from "../analysis.ts";
 
 interface SSAViewerProps {
   src: string;
   srcPos: IPosition;
-  ssa: string | undefined | null;
+  ssa: SSAFunction[] | string | null;
   theme: "light" | "dark";
 }
 
 export const SSAViewer: React.FC<SSAViewerProps> = (props: SSAViewerProps) => {
   let content: string;
 
-  if (props.ssa === undefined || props.ssa === null) {
+  if (props.ssa === null) {
     content = `SSA unavailable, try adding function declarations to the source`;
-  } else {
+  } else if (typeof props.ssa === "string") {
     content = props.ssa;
+  } else {
+    content = formatSSA(props.ssa);
   }
 
   return (

--- a/wasm/analysis.go
+++ b/wasm/analysis.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"go/parser"
+	"go/token"
+
+	astanalysis "github.com/yuxincs/goggle/ast"
+	cfganalysis "github.com/yuxincs/goggle/cfg"
+	ssaanalysis "github.com/yuxincs/goggle/ssa"
+)
+
+type Result struct {
+	AST  *astanalysis.Node       `json:"ast"`
+	CFGs []*cfganalysis.Function `json:"cfgs"`
+	SSA  []*ssaanalysis.Function `json:"ssa"`
+}
+
+func parse(src string) (*Result, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "main.go", src, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+
+	ssaFunctions, err := ssaanalysis.Analyze(fset, file)
+	if err != nil {
+		return nil, fmt.Errorf("build SSA: %w", err)
+	}
+
+	return &Result{
+		AST:  astanalysis.Analyze(fset, file),
+		CFGs: cfganalysis.Analyze(fset, file),
+		SSA:  ssaFunctions,
+	}, nil
+}

--- a/wasm/ast/ast.go
+++ b/wasm/ast/ast.go
@@ -1,0 +1,136 @@
+package ast
+
+import (
+	goast "go/ast"
+	"go/token"
+	"reflect"
+	"strings"
+
+	"github.com/yuxincs/goggle/source"
+)
+
+type Child struct {
+	Field string `json:"field"`
+	Index *int   `json:"index,omitempty"`
+	Node  *Node  `json:"node"`
+}
+
+type Node struct {
+	Type       string            `json:"type"`
+	Range      source.Range      `json:"range"`
+	Properties map[string]string `json:"properties,omitempty"`
+	Children   []*Child          `json:"children,omitempty"`
+}
+
+func Analyze(fset *token.FileSet, node goast.Node) *Node {
+	if node == nil {
+		return nil
+	}
+
+	result := &Node{
+		Type:       nodeType(node),
+		Range:      source.RangeFor(fset, node),
+		Properties: properties(node),
+	}
+
+	value := reflect.ValueOf(node)
+	if value.Kind() == reflect.Pointer {
+		value = value.Elem()
+	}
+	valueType := value.Type()
+
+	for fieldIndex := 0; fieldIndex < value.NumField(); fieldIndex++ {
+		field := value.Field(fieldIndex)
+		fieldName := valueType.Field(fieldIndex).Name
+
+		if child := nodeFromValue(field); child != nil {
+			result.Children = append(result.Children, &Child{
+				Field: fieldName,
+				Node:  Analyze(fset, child),
+			})
+			continue
+		}
+
+		if field.Kind() != reflect.Slice {
+			continue
+		}
+		for index := 0; index < field.Len(); index++ {
+			child := nodeFromValue(field.Index(index))
+			if child == nil {
+				continue
+			}
+			childIndex := index
+			result.Children = append(result.Children, &Child{
+				Field: fieldName,
+				Index: &childIndex,
+				Node:  Analyze(fset, child),
+			})
+		}
+	}
+
+	return result
+}
+
+func nodeFromValue(value reflect.Value) goast.Node {
+	if !value.IsValid() {
+		return nil
+	}
+	if value.Kind() == reflect.Interface {
+		if value.IsNil() {
+			return nil
+		}
+		value = value.Elem()
+	}
+	if value.Kind() == reflect.Pointer && value.IsNil() {
+		return nil
+	}
+	if !value.CanInterface() {
+		return nil
+	}
+	node, _ := value.Interface().(goast.Node)
+	return node
+}
+
+func nodeType(node goast.Node) string {
+	return strings.TrimPrefix(reflect.TypeOf(node).String(), "*ast.")
+}
+
+func properties(node goast.Node) map[string]string {
+	result := make(map[string]string)
+
+	switch node := node.(type) {
+	case *goast.File:
+		result["package"] = node.Name.Name
+	case *goast.Ident:
+		result["name"] = node.Name
+	case *goast.BasicLit:
+		result["token"] = node.Kind.String()
+		result["value"] = node.Value
+	case *goast.Comment:
+		result["text"] = node.Text
+	case *goast.AssignStmt:
+		result["token"] = node.Tok.String()
+	case *goast.BranchStmt:
+		result["token"] = node.Tok.String()
+	case *goast.IncDecStmt:
+		result["token"] = node.Tok.String()
+	case *goast.BinaryExpr:
+		result["operator"] = node.Op.String()
+	case *goast.UnaryExpr:
+		result["operator"] = node.Op.String()
+	case *goast.ChanType:
+		switch node.Dir {
+		case goast.SEND:
+			result["direction"] = "send"
+		case goast.RECV:
+			result["direction"] = "receive"
+		default:
+			result["direction"] = "bidirectional"
+		}
+	}
+
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}

--- a/wasm/cfg/cfg.go
+++ b/wasm/cfg/cfg.go
@@ -1,0 +1,99 @@
+package cfg
+
+import (
+	"bytes"
+	goast "go/ast"
+	"go/format"
+	"go/token"
+	"reflect"
+	"strings"
+
+	"github.com/yuxincs/goggle/source"
+	toolscfg "golang.org/x/tools/go/cfg"
+)
+
+type SyntaxNode struct {
+	Type   string       `json:"type"`
+	Range  source.Range `json:"range"`
+	Source string       `json:"source"`
+}
+
+type Block struct {
+	Index      int32         `json:"index"`
+	Kind       string        `json:"kind"`
+	Live       bool          `json:"live"`
+	Statement  *SyntaxNode   `json:"statement,omitempty"`
+	Nodes      []*SyntaxNode `json:"nodes"`
+	Successors []int32       `json:"successors"`
+}
+
+type Function struct {
+	Name     string       `json:"name"`
+	Range    source.Range `json:"range"`
+	NoReturn bool         `json:"noReturn"`
+	Blocks   []*Block     `json:"blocks"`
+}
+
+func Analyze(fset *token.FileSet, file *goast.File) []*Function {
+	functions := make([]*Function, 0)
+
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*goast.FuncDecl)
+		if !ok || function.Body == nil {
+			continue
+		}
+
+		graph := toolscfg.New(function.Body, func(*goast.CallExpr) bool { return true })
+		blocks := make([]*Block, 0, len(graph.Blocks))
+		for _, block := range graph.Blocks {
+			nodes := make([]*SyntaxNode, 0, len(block.Nodes))
+			for _, node := range block.Nodes {
+				nodes = append(nodes, newSyntaxNode(fset, node))
+			}
+
+			successors := make([]int32, 0, len(block.Succs))
+			for _, successor := range block.Succs {
+				successors = append(successors, successor.Index)
+			}
+
+			blocks = append(blocks, &Block{
+				Index:      block.Index,
+				Kind:       block.Kind.String(),
+				Live:       block.Live,
+				Statement:  newSyntaxNode(fset, block.Stmt),
+				Nodes:      nodes,
+				Successors: successors,
+			})
+		}
+
+		functions = append(functions, &Function{
+			Name:     function.Name.Name,
+			Range:    source.RangeFor(fset, function),
+			NoReturn: graph.NoReturn(),
+			Blocks:   blocks,
+		})
+	}
+
+	return functions
+}
+
+func newSyntaxNode(fset *token.FileSet, node goast.Node) *SyntaxNode {
+	if node == nil {
+		return nil
+	}
+
+	var formatted bytes.Buffer
+	if err := format.Node(&formatted, fset, node); err != nil {
+		formatted.WriteString(nodeType(node))
+	}
+
+	return &SyntaxNode{
+		Type:   nodeType(node),
+		Range:  source.RangeFor(fset, node),
+		Source: formatted.String(),
+	}
+}
+
+func nodeType(node goast.Node) string {
+	return strings.TrimPrefix(reflect.TypeOf(node).String(), "*ast.")
+}

--- a/wasm/main.go
+++ b/wasm/main.go
@@ -1,105 +1,19 @@
+//go:build js && wasm
+
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"go/ast"
-	"go/importer"
-	"go/parser"
-	"go/token"
-	"go/types"
-	"golang.org/x/tools/go/cfg"
-	"golang.org/x/tools/go/ssa"
-	"golang.org/x/tools/go/ssa/ssautil"
-
 	"syscall/js"
 )
-
-type CFGResult struct {
-	Name string `json:"name"`
-	Repr string `json:"repr"`
-	Dot  string `json:"dot"`
-}
-
-type Result struct {
-	AST  string       `json:"ast"`
-	CFGs []*CFGResult `json:"cfgs"`
-	SSA  string       `json:"ssa"`
-}
-
-func parse(src string) (*Result, error) {
-	result := &Result{}
-
-	// Parse the source and store the AST representations.
-	fset := token.NewFileSet()
-	f, err := parser.ParseFile(fset, "main.go", src, 0)
-	if err != nil {
-		return nil, err
-	}
-	var buf bytes.Buffer
-	if err := ast.Fprint(&buf, fset, f, nil); err != nil {
-		return nil, fmt.Errorf("print ast: %w", err)
-	}
-	result.AST = buf.String()
-
-	// Construct CFGs.
-	var graphs []*CFGResult
-	for _, decl := range f.Decls {
-		funcDecl, ok := decl.(*ast.FuncDecl)
-		if !ok {
-			continue
-		}
-		graph := cfg.New(funcDecl.Body, func(expr *ast.CallExpr) bool { return true })
-		position := fset.Position(funcDecl.Name.Pos())
-		name := fmt.Sprintf("%s:%d:%d", funcDecl.Name.Name, position.Line, position.Column)
-		graphs = append(graphs, &CFGResult{
-			Name: name,
-			Repr: graph.Format(fset),
-			Dot:  graph.Dot(fset),
-		})
-	}
-	result.CFGs = graphs
-
-	// Create the type-checker's package.
-	pkg := types.NewPackage("main", "")
-
-	files := []*ast.File{f}
-
-	// Type-check the package, load dependencies.
-	ssaPkg, typesInfo, err := ssautil.BuildPackage(&types.Config{Importer: importer.Default()}, fset, pkg, files, ssa.SanityCheckFunctions)
-	if err != nil {
-		return nil, fmt.Errorf("build packages: %w", err)
-	}
-
-	buf.Reset()
-	for _, decl := range f.Decls {
-		funcDecl, ok := decl.(*ast.FuncDecl)
-		if !ok {
-			continue
-		}
-		fn, ok := typesInfo.ObjectOf(funcDecl.Name).(*types.Func)
-		if !ok {
-			continue
-		}
-
-		ssaFunc := ssaPkg.Prog.FuncValue(fn)
-		position := fset.Position(funcDecl.Name.Pos())
-		name := fmt.Sprintf("%s:%d:%d", funcDecl.Name.Name, position.Line, position.Column)
-		buf.WriteString(name + "\n")
-		ssa.WriteFunction(&buf, ssaFunc)
-	}
-	result.SSA = buf.String()
-
-	return result, nil
-}
 
 func main() {
 	js.Global().Set("parse", js.FuncOf(func(this js.Value, args []js.Value) (output any) {
 		defer func() {
-			if r := recover(); r != nil {
+			if recovered := recover(); recovered != nil {
 				output = js.ValueOf(map[string]interface{}{
-					"error": fmt.Sprintf("%s", r),
+					"error": fmt.Sprintf("%s", recovered),
 				})
 			}
 		}()
@@ -132,6 +46,6 @@ func main() {
 		})
 	}))
 
-	// Wait forever to keep the Go wasm module running.
+	// Wait forever to keep the Go WebAssembly module running.
 	<-make(chan struct{})
 }

--- a/wasm/source/source.go
+++ b/wasm/source/source.go
@@ -1,0 +1,33 @@
+package source
+
+import (
+	"go/ast"
+	"go/token"
+)
+
+type Position struct {
+	Offset int `json:"offset"`
+	Line   int `json:"line"`
+	Column int `json:"column"`
+}
+
+type Range struct {
+	Start Position `json:"start"`
+	End   Position `json:"end"`
+}
+
+func PositionFor(fset *token.FileSet, pos token.Pos) Position {
+	position := fset.PositionFor(pos, false)
+	return Position{
+		Offset: position.Offset,
+		Line:   position.Line,
+		Column: position.Column,
+	}
+}
+
+func RangeFor(fset *token.FileSet, node ast.Node) Range {
+	return Range{
+		Start: PositionFor(fset, node.Pos()),
+		End:   PositionFor(fset, node.End()),
+	}
+}

--- a/wasm/ssa/ssa.go
+++ b/wasm/ssa/ssa.go
@@ -1,0 +1,155 @@
+package ssa
+
+import (
+	goast "go/ast"
+	"go/importer"
+	"go/token"
+	"go/types"
+	"reflect"
+	"strings"
+
+	"github.com/yuxincs/goggle/source"
+	toolsssa "golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/ssa/ssautil"
+)
+
+type Value struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type Instruction struct {
+	Index    int              `json:"index"`
+	Opcode   string           `json:"opcode"`
+	Text     string           `json:"text"`
+	Position *source.Position `json:"position,omitempty"`
+	Result   *Value           `json:"result,omitempty"`
+	Operands []*Value         `json:"operands"`
+}
+
+type Block struct {
+	Index        int            `json:"index"`
+	Comment      string         `json:"comment,omitempty"`
+	Predecessors []int          `json:"predecessors"`
+	Successors   []int          `json:"successors"`
+	Instructions []*Instruction `json:"instructions"`
+}
+
+type Function struct {
+	Name       string          `json:"name"`
+	Signature  string          `json:"signature"`
+	Position   source.Position `json:"position"`
+	Parameters []*Value        `json:"parameters"`
+	Blocks     []*Block        `json:"blocks"`
+}
+
+func Analyze(fset *token.FileSet, file *goast.File) ([]*Function, error) {
+	pkg := types.NewPackage("main", "")
+	ssaPkg, typesInfo, err := ssautil.BuildPackage(
+		&types.Config{Importer: importer.Default()},
+		fset,
+		pkg,
+		[]*goast.File{file},
+		toolsssa.SanityCheckFunctions,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	functions := make([]*Function, 0)
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*goast.FuncDecl)
+		if !ok {
+			continue
+		}
+		object, ok := typesInfo.ObjectOf(function.Name).(*types.Func)
+		if !ok {
+			continue
+		}
+		ssaFunction := ssaPkg.Prog.FuncValue(object)
+		if ssaFunction == nil {
+			continue
+		}
+
+		parameters := make([]*Value, 0, len(ssaFunction.Params))
+		for _, parameter := range ssaFunction.Params {
+			parameters = append(parameters, newValue(parameter))
+		}
+
+		blocks := make([]*Block, 0, len(ssaFunction.Blocks))
+		for _, block := range ssaFunction.Blocks {
+			instructions := make([]*Instruction, 0, len(block.Instrs))
+			for index, instruction := range block.Instrs {
+				instructions = append(instructions, newInstruction(fset, index, instruction))
+			}
+
+			blocks = append(blocks, &Block{
+				Index:        block.Index,
+				Comment:      block.Comment,
+				Predecessors: blockIndexes(block.Preds),
+				Successors:   blockIndexes(block.Succs),
+				Instructions: instructions,
+			})
+		}
+
+		functions = append(functions, &Function{
+			Name:       function.Name.Name,
+			Signature:  ssaFunction.Signature.String(),
+			Position:   source.PositionFor(fset, ssaFunction.Pos()),
+			Parameters: parameters,
+			Blocks:     blocks,
+		})
+	}
+
+	return functions, nil
+}
+
+func newInstruction(fset *token.FileSet, index int, instruction toolsssa.Instruction) *Instruction {
+	result := &Instruction{
+		Index:    index,
+		Opcode:   strings.TrimPrefix(reflect.TypeOf(instruction).String(), "*ssa."),
+		Text:     instruction.String(),
+		Operands: make([]*Value, 0),
+	}
+
+	if instruction.Pos().IsValid() {
+		position := source.PositionFor(fset, instruction.Pos())
+		result.Position = &position
+	}
+	if value, ok := instruction.(toolsssa.Value); ok {
+		result.Result = newValue(value)
+	}
+	for _, operand := range instruction.Operands(nil) {
+		if operand == nil || *operand == nil {
+			continue
+		}
+		result.Operands = append(result.Operands, newValue(*operand))
+	}
+
+	return result
+}
+
+func newValue(value toolsssa.Value) *Value {
+	if value == nil {
+		return nil
+	}
+
+	typeName := ""
+	if value.Type() != nil {
+		typeName = value.Type().String()
+	}
+	return &Value{
+		Name: value.Name(),
+		Type: typeName,
+		Text: value.String(),
+	}
+}
+
+func blockIndexes(blocks []*toolsssa.BasicBlock) []int {
+	indexes := make([]int, 0, len(blocks))
+	for _, block := range blocks {
+		indexes = append(indexes, block.Index)
+	}
+	return indexes
+}


### PR DESCRIPTION
Return AST, CFG, and SSA analyses as typed JSON structures instead of formatted text dumps.

Split the WebAssembly analyzers into dedicated ast, cfg, and ssa packages, add shared source ranges, and update the frontend to format the structured data for the existing viewers.