### PR TITLE
Synchronize pane line selection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -101,7 +101,21 @@ export const App = () => {
     setSSA(body.ssa);
   };
 
-  const handleSrcPosChange = (pos: IPosition) => setSrcPos(pos);
+  const handleSrcPosChange = (pos: IPosition) => {
+    setSrcPos((current) =>
+      current.lineNumber === pos.lineNumber && current.column === pos.column
+        ? current
+        : pos
+    );
+  };
+
+  const handleAnalysisLineSelect = (lineNumber: number) => {
+    setSrcPos((current) =>
+      current.lineNumber === lineNumber
+        ? current
+        : { lineNumber, column: 1 }
+    );
+  };
 
   const hasError = typeof ast === "string" && ast.startsWith("ERROR:");
 
@@ -173,7 +187,7 @@ export const App = () => {
           <section className="panel panel--source" aria-label="Go source editor">
             <SourceEditor
               initialContent={src}
-              initialPosition={srcPos}
+              position={srcPos}
               onChange={handleSrcChange}
               onCursorChange={(event) => handleSrcPosChange(event.position)}
               theme={theme}
@@ -181,7 +195,12 @@ export const App = () => {
           </section>
 
           <section className="panel" aria-label="Control flow graph">
-            <CFGViewer src={src} srcPos={srcPos} cfgs={cfgs} theme={theme} />
+            <CFGViewer
+              cfgs={cfgs}
+              sourceLine={srcPos.lineNumber}
+              onSourceLineSelect={handleAnalysisLineSelect}
+              theme={theme}
+            />
           </section>
 
           <div
@@ -206,11 +225,21 @@ export const App = () => {
           style={{ gridTemplateRows: `${rightRowSplit}fr ${100 - rightRowSplit}fr` }}
         >
           <section className="panel" aria-label="Abstract syntax tree">
-            <ASTViewer src={src} srcPos={srcPos} ast={ast} theme={theme} />
+            <ASTViewer
+              ast={ast}
+              sourceLine={srcPos.lineNumber}
+              onSourceLineSelect={handleAnalysisLineSelect}
+              theme={theme}
+            />
           </section>
 
           <section className="panel" aria-label="Static single assignment form">
-            <SSAViewer src={src} srcPos={srcPos} ssa={ssa} theme={theme} />
+            <SSAViewer
+              ssa={ssa}
+              sourceLine={srcPos.lineNumber}
+              onSourceLineSelect={handleAnalysisLineSelect}
+              theme={theme}
+            />
           </section>
 
           <div

--- a/src/viewers/CodeViewer.tsx
+++ b/src/viewers/CodeViewer.tsx
@@ -17,6 +17,9 @@ export interface CodeViewerProps {
 
 export const CodeViewer = (props: CodeViewerProps) => {
   const editorRef = useRef<editor.IStandaloneCodeEditor>(null);
+  const onCursorChangeRef = useRef(props.onCursorChange);
+  const suppressCursorChangeRef = useRef(false);
+  onCursorChangeRef.current = props.onCursorChange;
 
   // We intentionally do not use the `value` and `line` props of the `Editor` component since it does not provide
   // a way to reveal the line in center (it puts the line as the first line, which leads to bad UX). This means we
@@ -28,12 +31,25 @@ export const CodeViewer = (props: CodeViewerProps) => {
     if (ref == null) {
       return;
     }
-    if (content !== undefined) {
-      ref.setValue(content);
+    const shouldUpdateContent = content !== undefined &&
+      ref.getValue() !== content;
+    const shouldUpdateLine = line !== undefined &&
+      (shouldUpdateContent || ref.getPosition()?.lineNumber !== line);
+    if (!shouldUpdateContent && !shouldUpdateLine) {
+      return;
     }
-    if (line !== undefined) {
-      ref.revealLineInCenterIfOutsideViewport(line, ScrollType.Smooth);
-      ref.setPosition({ lineNumber: line, column: 1 });
+
+    suppressCursorChangeRef.current = true;
+    try {
+      if (shouldUpdateContent) {
+        ref.setValue(content);
+      }
+      if (shouldUpdateLine) {
+        ref.revealLineInCenterIfOutsideViewport(line, ScrollType.Smooth);
+        ref.setPosition({ lineNumber: line, column: 1 });
+      }
+    } finally {
+      suppressCursorChangeRef.current = false;
     }
   };
 
@@ -42,15 +58,19 @@ export const CodeViewer = (props: CodeViewerProps) => {
     editorRef.current = editor;
 
     // Register cursor position change listener.
-    if (props.onCursorChange !== undefined) {
-      editor.onDidChangeCursorPosition(props.onCursorChange);
-    }
+    editor.onDidChangeCursorPosition((event) => {
+      if (!suppressCursorChangeRef.current) {
+        onCursorChangeRef.current?.(event);
+      }
+    });
 
-    // Set the initial content and line if given.
-    if (props.initialContent == null && props.initialLine == null) {
+    // Set the controlled values, falling back to initial values when given.
+    const content = props.content ?? props.initialContent;
+    const line = props.line ?? props.initialLine;
+    if (content == null && line == null) {
       return;
     }
-    update(props.initialContent, props.initialLine);
+    update(content, line);
   };
 
   const handleOnChange = (code: string | undefined) => {

--- a/src/viewers/SourceEditor.tsx
+++ b/src/viewers/SourceEditor.tsx
@@ -7,7 +7,7 @@ interface SourceEditorProps {
   onChange: (code: string | undefined) => void;
   onCursorChange: (event: editor.ICursorPositionChangedEvent) => void;
   initialContent: string;
-  initialPosition: IPosition;
+  position: IPosition;
   theme: "light" | "dark";
 }
 
@@ -17,7 +17,8 @@ export const SourceEditor = (props: SourceEditorProps) => {
       <ViewerTitle sx={{ height: VIEWER_TITLE_HEIGHT }}>Go Source</ViewerTitle>
       <CodeViewer
         initialContent={props.initialContent}
-        initialLine={props.initialPosition.lineNumber}
+        initialLine={props.position.lineNumber}
+        line={props.position.lineNumber}
         onChange={props.onChange}
         onCursorChange={props.onCursorChange}
         theme={props.theme}

--- a/src/viewers/ast/ASTViewer.tsx
+++ b/src/viewers/ast/ASTViewer.tsx
@@ -1,31 +1,52 @@
 import { CodeViewer } from "../CodeViewer.tsx";
-import React from "react";
-import { IPosition } from "monaco-editor";
+import React, { useMemo } from "react";
 import { ViewerTitle } from "../ViewerTitle.tsx";
 import { VIEWER_TITLE_HEIGHT } from "../../constants.ts";
 import { ASTNode } from "../../analysis.ts";
 import { formatAST } from "./format.ts";
+import {
+  displayLineForSourceLine,
+  FormattedAnalysis,
+  sourceLineForDisplayLine,
+} from "../lineMapping.ts";
 
 interface ASTViewerProps {
-  src: string;
-  srcPos: IPosition;
   ast: ASTNode | string | null;
+  sourceLine: number;
+  onSourceLineSelect: (line: number) => void;
   theme: "light" | "dark";
 }
 
 export const ASTViewer: React.FC<ASTViewerProps> = (props: ASTViewerProps) => {
-  const content = props.ast === null
-    ? "AST unavailable"
-    : typeof props.ast === "string"
-      ? props.ast
-      : formatAST(props.ast);
+  const formatted = useMemo<FormattedAnalysis>(() => {
+    if (props.ast === null) {
+      return { content: "AST unavailable", sourceLines: [] };
+    }
+    if (typeof props.ast === "string") {
+      return { content: props.ast, sourceLines: [] };
+    }
+    return formatAST(props.ast);
+  }, [props.ast]);
+  const displayLine = displayLineForSourceLine(
+    formatted.sourceLines,
+    props.sourceLine,
+  );
 
   return (
     <>
       <ViewerTitle sx={{ height: VIEWER_TITLE_HEIGHT }}>AST</ViewerTitle>
       <CodeViewer
-        content={content}
-        line={props.srcPos.lineNumber}
+        content={formatted.content}
+        line={displayLine}
+        onCursorChange={(event) => {
+          const sourceLine = sourceLineForDisplayLine(
+            formatted.sourceLines,
+            event.position.lineNumber,
+          );
+          if (sourceLine !== undefined) {
+            props.onSourceLineSelect(sourceLine);
+          }
+        }}
         readOnly={true}
         theme={props.theme}
         height={`calc(100% - ${VIEWER_TITLE_HEIGHT})`}

--- a/src/viewers/ast/format.ts
+++ b/src/viewers/ast/format.ts
@@ -1,12 +1,14 @@
 import { ASTNode, SourceRange } from "../../analysis.ts";
+import { FormattedAnalysis } from "../lineMapping.ts";
 
 const formatPosition = (line: number, column: number) => `${line}:${column}`;
 
 const formatRange = (range: SourceRange) =>
   `${formatPosition(range.start.line, range.start.column)}-${formatPosition(range.end.line, range.end.column)}`;
 
-export const formatAST = (root: ASTNode): string => {
+export const formatAST = (root: ASTNode): FormattedAnalysis => {
   const lines: string[] = [];
+  const sourceLines: number[] = [];
 
   const visit = (node: ASTNode, depth: number, label?: string) => {
     const indentation = "  ".repeat(depth);
@@ -18,6 +20,7 @@ export const formatAST = (root: ASTNode): string => {
     lines.push(
       `${indentation}${prefix}${node.type} [${formatRange(node.range)}]${properties === "" ? "" : ` ${properties}`}`,
     );
+    sourceLines.push(node.range.start.line);
 
     for (const child of node.children ?? []) {
       const childLabel = child.index === undefined
@@ -28,5 +31,8 @@ export const formatAST = (root: ASTNode): string => {
   };
 
   visit(root, 0);
-  return lines.join("\n");
+  return {
+    content: lines.join("\n"),
+    sourceLines,
+  };
 };

--- a/src/viewers/cfg/CFGViewer.tsx
+++ b/src/viewers/cfg/CFGViewer.tsx
@@ -1,35 +1,55 @@
 import { CodeViewer } from "../CodeViewer.tsx";
-import React from "react";
-import { IPosition } from "monaco-editor";
+import React, { useMemo } from "react";
 import { ViewerTitle } from "../ViewerTitle.tsx";
 import { VIEWER_TITLE_HEIGHT } from "../../constants.ts";
 import { CFGFunction } from "../../analysis.ts";
 import { formatCFGs } from "./format.ts";
+import {
+  displayLineForSourceLine,
+  FormattedAnalysis,
+  sourceLineForDisplayLine,
+} from "../lineMapping.ts";
 
 interface CFGViewerProps {
-  src: string;
-  srcPos: IPosition;
   cfgs: CFGFunction[] | string | null;
+  sourceLine: number;
+  onSourceLineSelect: (line: number) => void;
   theme: "light" | "dark";
 }
 
 export const CFGViewer: React.FC<CFGViewerProps> = (props: CFGViewerProps) => {
-  let content: string;
-
-  if (props.cfgs === null) {
-    content = `CFG unavailable, try adding function declarations to the source`;
-  } else if (typeof props.cfgs === "string") {
-    content = props.cfgs;
-  } else {
-    content = formatCFGs(props.cfgs);
-  }
+  const formatted = useMemo<FormattedAnalysis>(() => {
+    if (props.cfgs === null) {
+      return {
+        content: "CFG unavailable, try adding function declarations to the source",
+        sourceLines: [],
+      };
+    }
+    if (typeof props.cfgs === "string") {
+      return { content: props.cfgs, sourceLines: [] };
+    }
+    return formatCFGs(props.cfgs);
+  }, [props.cfgs]);
+  const displayLine = displayLineForSourceLine(
+    formatted.sourceLines,
+    props.sourceLine,
+  );
 
   return (
     <>
       <ViewerTitle sx={{ height: VIEWER_TITLE_HEIGHT }}>CFG</ViewerTitle>
       <CodeViewer
-        content={content}
-        line={props.srcPos.lineNumber}
+        content={formatted.content}
+        line={displayLine}
+        onCursorChange={(event) => {
+          const sourceLine = sourceLineForDisplayLine(
+            formatted.sourceLines,
+            event.position.lineNumber,
+          );
+          if (sourceLine !== undefined) {
+            props.onSourceLineSelect(sourceLine);
+          }
+        }}
         readOnly={true}
         theme={props.theme}
         height={`calc(100% - ${VIEWER_TITLE_HEIGHT})`}

--- a/src/viewers/cfg/format.ts
+++ b/src/viewers/cfg/format.ts
@@ -1,43 +1,66 @@
 import { CFGFunction, SourceRange } from "../../analysis.ts";
+import { FormattedAnalysis } from "../lineMapping.ts";
 
 const formatPosition = (line: number, column: number) => `${line}:${column}`;
 
 const formatRange = (range: SourceRange) =>
   `${formatPosition(range.start.line, range.start.column)}-${formatPosition(range.end.line, range.end.column)}`;
 
-const indentMultiline = (value: string, indentation: string) =>
-  value.split("\n").join(`\n${indentation}`);
-
-export const formatCFGs = (functions: CFGFunction[]): string => {
+export const formatCFGs = (functions: CFGFunction[]): FormattedAnalysis => {
   if (functions.length === 0) {
-    return "CFG unavailable, try adding function declarations to the source";
+    return {
+      content: "CFG unavailable, try adding function declarations to the source",
+      sourceLines: [],
+    };
   }
 
-  return functions.map((fn) => {
-    const lines = [
-      `func ${fn.name} [${formatRange(fn.range)}]${fn.noReturn ? " (no return)" : ""}`,
-    ];
+  const lines: string[] = [];
+  const sourceLines: Array<number | null> = [];
+  const append = (text: string, sourceLine: number | null) => {
+    for (const [index, part] of text.split("\n").entries()) {
+      lines.push(index === 0 ? part : `  ${part}`);
+      sourceLines.push(sourceLine === null ? null : sourceLine + index);
+    }
+  };
 
+  functions.forEach((fn, functionIndex) => {
+    if (functionIndex > 0) {
+      append("", null);
+    }
+    append(
+      `func ${fn.name} [${formatRange(fn.range)}]${fn.noReturn ? " (no return)" : ""}`,
+      fn.range.start.line,
+    );
     for (const block of fn.blocks) {
-      lines.push(
-        "",
+      const blockLine = block.statement?.range.start.line ??
+        block.nodes[0]?.range.start.line ??
+        fn.range.start.line;
+      append("", null);
+      append(
         `block ${block.index} (${block.kind})${block.live ? "" : " [unreachable]"}`,
+        blockLine,
       );
       if (block.statement !== undefined) {
-        lines.push(
+        append(
           `  control: ${block.statement.type} [${formatRange(block.statement.range)}]`,
+          block.statement.range.start.line,
         );
       }
       for (const node of block.nodes) {
-        lines.push(
-          `  ${node.type} [${formatRange(node.range)}] ${indentMultiline(node.source, "  ")}`,
+        append(
+          `  ${node.type} [${formatRange(node.range)}] ${node.source}`,
+          node.range.start.line,
         );
       }
-      lines.push(
+      append(
         `  successors: ${block.successors.length === 0 ? "none" : block.successors.join(", ")}`,
+        blockLine,
       );
     }
+  });
 
-    return lines.join("\n");
-  }).join("\n\n");
+  return {
+    content: lines.join("\n"),
+    sourceLines,
+  };
 };

--- a/src/viewers/lineMapping.ts
+++ b/src/viewers/lineMapping.ts
@@ -1,0 +1,49 @@
+export interface FormattedAnalysis {
+  content: string;
+  sourceLines: Array<number | null>;
+}
+
+export const sourceLineForDisplayLine = (
+  sourceLines: Array<number | null>,
+  displayLine: number,
+): number | undefined => {
+  const index = displayLine - 1;
+  const direct = sourceLines[index];
+  if (direct !== undefined && direct !== null) {
+    return direct;
+  }
+
+  for (let distance = 1; distance < sourceLines.length; distance++) {
+    const before = sourceLines[index - distance];
+    if (before !== undefined && before !== null) {
+      return before;
+    }
+    const after = sourceLines[index + distance];
+    if (after !== undefined && after !== null) {
+      return after;
+    }
+  }
+
+  return undefined;
+};
+
+export const displayLineForSourceLine = (
+  sourceLines: Array<number | null>,
+  sourceLine: number,
+): number | undefined => {
+  let closestIndex: number | undefined;
+  let closestDistance = Number.POSITIVE_INFINITY;
+
+  sourceLines.forEach((candidate, index) => {
+    if (candidate === null) {
+      return;
+    }
+    const distance = Math.abs(candidate - sourceLine);
+    if (distance < closestDistance) {
+      closestIndex = index;
+      closestDistance = distance;
+    }
+  });
+
+  return closestIndex === undefined ? undefined : closestIndex + 1;
+};

--- a/src/viewers/ssa/SSAViewer.tsx
+++ b/src/viewers/ssa/SSAViewer.tsx
@@ -1,35 +1,55 @@
 import { CodeViewer } from "../CodeViewer.tsx";
-import React from "react";
-import { IPosition } from "monaco-editor";
+import React, { useMemo } from "react";
 import { ViewerTitle } from "../ViewerTitle.tsx";
 import { VIEWER_TITLE_HEIGHT } from "../../constants.ts";
 import { SSAFunction } from "../../analysis.ts";
 import { formatSSA } from "./format.ts";
+import {
+  displayLineForSourceLine,
+  FormattedAnalysis,
+  sourceLineForDisplayLine,
+} from "../lineMapping.ts";
 
 interface SSAViewerProps {
-  src: string;
-  srcPos: IPosition;
   ssa: SSAFunction[] | string | null;
+  sourceLine: number;
+  onSourceLineSelect: (line: number) => void;
   theme: "light" | "dark";
 }
 
 export const SSAViewer: React.FC<SSAViewerProps> = (props: SSAViewerProps) => {
-  let content: string;
-
-  if (props.ssa === null) {
-    content = `SSA unavailable, try adding function declarations to the source`;
-  } else if (typeof props.ssa === "string") {
-    content = props.ssa;
-  } else {
-    content = formatSSA(props.ssa);
-  }
+  const formatted = useMemo<FormattedAnalysis>(() => {
+    if (props.ssa === null) {
+      return {
+        content: "SSA unavailable, try adding function declarations to the source",
+        sourceLines: [],
+      };
+    }
+    if (typeof props.ssa === "string") {
+      return { content: props.ssa, sourceLines: [] };
+    }
+    return formatSSA(props.ssa);
+  }, [props.ssa]);
+  const displayLine = displayLineForSourceLine(
+    formatted.sourceLines,
+    props.sourceLine,
+  );
 
   return (
     <>
       <ViewerTitle sx={{ height: VIEWER_TITLE_HEIGHT }}>SSA</ViewerTitle>
       <CodeViewer
-        content={content}
-        line={props.srcPos.lineNumber}
+        content={formatted.content}
+        line={displayLine}
+        onCursorChange={(event) => {
+          const sourceLine = sourceLineForDisplayLine(
+            formatted.sourceLines,
+            event.position.lineNumber,
+          );
+          if (sourceLine !== undefined) {
+            props.onSourceLineSelect(sourceLine);
+          }
+        }}
         readOnly={true}
         theme={props.theme}
         height={`calc(100% - ${VIEWER_TITLE_HEIGHT})`}

--- a/src/viewers/ssa/format.ts
+++ b/src/viewers/ssa/format.ts
@@ -1,20 +1,35 @@
 import { SourcePosition, SSAFunction } from "../../analysis.ts";
+import { FormattedAnalysis } from "../lineMapping.ts";
 
 const formatPosition = (position: SourcePosition) =>
   `${position.line}:${position.column}`;
 
-export const formatSSA = (functions: SSAFunction[]): string => {
+export const formatSSA = (functions: SSAFunction[]): FormattedAnalysis => {
   if (functions.length === 0) {
-    return "SSA unavailable, try adding function declarations to the source";
+    return {
+      content: "SSA unavailable, try adding function declarations to the source",
+      sourceLines: [],
+    };
   }
 
-  return functions.map((fn) => {
+  const lines: string[] = [];
+  const sourceLines: Array<number | null> = [];
+  const append = (text: string, sourceLine: number | null) => {
+    lines.push(text);
+    sourceLines.push(sourceLine);
+  };
+
+  functions.forEach((fn, functionIndex) => {
+    if (functionIndex > 0) {
+      append("", null);
+    }
     const signature = fn.signature.startsWith("func")
       ? fn.signature.slice("func".length)
       : ` ${fn.signature}`;
-    const lines = [
+    append(
       `func ${fn.name}${signature} [${formatPosition(fn.position)}]`,
-    ];
+      fn.position.line,
+    );
 
     for (const block of fn.blocks) {
       const comment = block.comment === "" || block.comment === undefined
@@ -26,9 +41,13 @@ export const formatSSA = (functions: SSAFunction[]): string => {
       const successors = block.successors.length === 0
         ? "none"
         : block.successors.join(", ");
-      lines.push(
-        "",
+      const blockLine = block.instructions.find((instruction) =>
+        instruction.position !== undefined
+      )?.position?.line ?? fn.position.line;
+      append("", null);
+      append(
         `block ${block.index}${comment}  predecessors: ${predecessors}  successors: ${successors}`,
+        blockLine,
       );
 
       for (const instruction of block.instructions) {
@@ -40,12 +59,16 @@ export const formatSSA = (functions: SSAFunction[]): string => {
             instruction.result.type === ""
           ? ""
           : `  // ${instruction.result.type}`;
-        lines.push(
+        append(
           `  ${instruction.index}: ${result}${instruction.text}${resultType}`,
+          instruction.position?.line ?? blockLine,
         );
       }
     }
+  });
 
-    return lines.join("\n");
-  }).join("\n\n");
+  return {
+    content: lines.join("\n"),
+    sourceLines,
+  };
 };


### PR DESCRIPTION
Synchronize cursor lines across the source, AST, CFG, and SSA panes using formatter-provided source-line mappings.

Use nearest-line fallback when an exact source line is unavailable, and suppress programmatic Monaco cursor events to prevent synchronization feedback loops.

Validation: npm run build