### PR TITLE
Fix WASM and editor startup races

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,7 @@ export const App = () => {
   const [src, setSrc] = useState<string>(storedSrc);
   const [srcPos, setSrcPos] = useState<IPosition>(storedPos);
   const [isReady, setIsReady] = useState(false);
+  const [isSourceReady, setIsSourceReady] = useState(false);
   const [theme, setTheme] = useState<"light" | "dark">(storedTheme);
   const [columnSplit, setColumnSplit] = useState(50);
   const [leftRowSplit, setLeftRowSplit] = useState(50);
@@ -54,11 +55,27 @@ export const App = () => {
   // Start Go WebAssembly such that the parse function is available in global this.
   // Then, load the source and position from local storage and set then.
   useEffect(() => {
-    loadGoggleWasm().then(() => {
-      setIsReady(true);
-      handleSrcChange(storedSrc);
-      handleSrcPosChange(storedPos);
-    });
+    let isCurrent = true;
+
+    loadGoggleWasm()
+      .then(() => {
+        if (!isCurrent) return;
+        handleSrcChange(storedSrc);
+        handleSrcPosChange(storedPos);
+        setIsReady(true);
+      })
+      .catch((error: unknown) => {
+        if (!isCurrent) return;
+        const message = error instanceof Error ? error.message : String(error);
+        setAST(`ERROR: ${message}`);
+        setCFGs(`ERROR: ${message}`);
+        setSSA(`ERROR: ${message}`);
+        setIsReady(true);
+      });
+
+    return () => {
+      isCurrent = false;
+    };
   }, []);
 
   // Update source and position in local storage anytime they change.
@@ -119,6 +136,7 @@ export const App = () => {
 
   const hasError = typeof ast === "string" && ast.startsWith("ERROR:");
   const isAnalysisReady = isReady &&
+    isSourceReady &&
     typeof ast !== "string" &&
     Array.isArray(cfgs) &&
     Array.isArray(ssa);
@@ -198,6 +216,7 @@ export const App = () => {
               position={srcPos}
               onChange={handleSrcChange}
               onCursorChange={(event) => handleSrcPosChange(event.position)}
+              onReady={() => setIsSourceReady(true)}
               theme={theme}
             />
           </section>

--- a/src/utils/wasm.ts
+++ b/src/utils/wasm.ts
@@ -1,14 +1,37 @@
 import "../assets/wasm_exec.js";
 import goggleWasm from "../assets/goggle.wasm?url";
 
-let isGoggleWasmLoaded = false;
+const PARSER_TIMEOUT = 30_000;
+let loadPromise: Promise<void> | undefined;
 
-export const loadGoggleWasm = async () => {
-  // Guard the load function such that we do not load the Go wasm module more than once.
-  if (isGoggleWasmLoaded) {
+const isParserReady = () => {
+  // @ts-expect-error: `parse` is injected into global this by the Goggle WebAssembly module.
+  return typeof globalThis.parse === "function";
+};
+
+const waitForParser = () => new Promise<void>((resolve, reject) => {
+  const deadline = performance.now() + PARSER_TIMEOUT;
+
+  const check = () => {
+    if (isParserReady()) {
+      resolve();
+      return;
+    }
+    if (performance.now() >= deadline) {
+      reject(new Error("Go WebAssembly parser initialization timed out"));
+      return;
+    }
+    window.setTimeout(check, 10);
+  };
+
+  check();
+});
+
+const initializeGoggleWasm = async () => {
+  if (isParserReady()) {
     return;
   }
-  isGoggleWasmLoaded = true;
+
   // @ts-expect-error: `Go` is imported in global this by `wasm_exec.js` file.
   const go = new Go();
   const result = await WebAssembly.instantiateStreaming(
@@ -18,5 +41,16 @@ export const loadGoggleWasm = async () => {
   console.log("Go WebAssembly started");
 
   // Run the instance without waiting since Go Assembly would be running forever to provide the functionality.
-  go.run(result.instance);
+  void go.run(result.instance);
+  await waitForParser();
+};
+
+export const loadGoggleWasm = () => {
+  if (loadPromise === undefined) {
+    loadPromise = initializeGoggleWasm().catch((error) => {
+      loadPromise = undefined;
+      throw error;
+    });
+  }
+  return loadPromise;
 };

--- a/src/viewers/CodeViewer.tsx
+++ b/src/viewers/CodeViewer.tsx
@@ -1,5 +1,5 @@
 import { editor } from "monaco-editor";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Editor } from "@monaco-editor/react";
 import ScrollType = editor.ScrollType;
 
@@ -11,17 +11,23 @@ export interface CodeViewerProps {
   readonly height?: string | number;
   readonly onChange?: (code: string) => void;
   readonly onCursorChange?: (event: editor.ICursorPositionChangedEvent) => void;
+  readonly onReady?: () => void;
   readonly readOnly?: boolean;
   readonly theme?: "light" | "dark";
 }
 
 export const CodeViewer = (props: CodeViewerProps) => {
   const editorRef = useRef<editor.IStandaloneCodeEditor>(null);
+  const [mountedEditor, setMountedEditor] = useState<editor.IStandaloneCodeEditor | null>(null);
   const onCursorChangeRef = useRef(props.onCursorChange);
+  const onReadyRef = useRef(props.onReady);
   const suppressCursorChangeRef = useRef(false);
   useEffect(() => {
     onCursorChangeRef.current = props.onCursorChange;
   }, [props.onCursorChange]);
+  useEffect(() => {
+    onReadyRef.current = props.onReady;
+  }, [props.onReady]);
 
   // We intentionally do not use the `value` and `line` props of the `Editor` component since it does not provide
   // a way to reveal the line in center (it puts the line as the first line, which leads to bad UX). This means we
@@ -58,6 +64,7 @@ export const CodeViewer = (props: CodeViewerProps) => {
   const handleOnMount = (editor: editor.IStandaloneCodeEditor) => {
     // Keep a ref for other uses.
     editorRef.current = editor;
+    setMountedEditor(editor);
 
     // Register cursor position change listener.
     editor.onDidChangeCursorPosition((event) => {
@@ -65,14 +72,6 @@ export const CodeViewer = (props: CodeViewerProps) => {
         onCursorChangeRef.current?.(event);
       }
     });
-
-    // Set the controlled values, falling back to initial values when given.
-    const content = props.content ?? props.initialContent;
-    const line = props.line ?? props.initialLine;
-    if (content == null && line == null) {
-      return;
-    }
-    update(content, line);
   };
 
   const handleOnChange = (code: string | undefined) => {
@@ -83,8 +82,20 @@ export const CodeViewer = (props: CodeViewerProps) => {
   };
 
   useEffect(() => {
-    update(props.content, props.line);
-  }, [props.content, props.line, update]);
+    if (mountedEditor === null) return;
+    update(
+      props.content ?? props.initialContent,
+      props.line ?? props.initialLine,
+    );
+    onReadyRef.current?.();
+  }, [
+    mountedEditor,
+    props.content,
+    props.initialContent,
+    props.line,
+    props.initialLine,
+    update,
+  ]);
 
   return (
     <Editor

--- a/src/viewers/SourceEditor.tsx
+++ b/src/viewers/SourceEditor.tsx
@@ -6,6 +6,7 @@ import { VIEWER_TITLE_HEIGHT } from "../constants.ts";
 interface SourceEditorProps {
   onChange: (code: string | undefined) => void;
   onCursorChange: (event: editor.ICursorPositionChangedEvent) => void;
+  onReady: () => void;
   initialContent: string;
   position: IPosition;
   theme: "light" | "dark";
@@ -21,6 +22,7 @@ export const SourceEditor = (props: SourceEditorProps) => {
         line={props.position.lineNumber}
         onChange={props.onChange}
         onCursorChange={props.onCursorChange}
+        onReady={props.onReady}
         theme={props.theme}
         height={`calc(100% - ${VIEWER_TITLE_HEIGHT})`}
       />


### PR DESCRIPTION
## Summary
- share the in-flight WASM initialization and wait for the parser export before analyzing source
- ignore stale StrictMode startup callbacks
- reapply current content after Monaco mounts and include source readiness in the screenshot signal

## Validation
- npm run lint
- npm run build