### PR TITLE
Support standard library imports in WASM

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,9 @@ jobs:
 
       - name: Run Go unit tests in WebAssembly
         working-directory: wasm
-        run: GOOS=js GOARCH=wasm go test -exec="$(go env GOROOT)/lib/wasm/go_js_wasm_exec" ./...
+        run: |
+          go generate ./...
+          GOOS=js GOARCH=wasm go test -exec="$(go env GOROOT)/lib/wasm/go_js_wasm_exec" ./...
 
   build:
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ dist-ssr
 # Will be generated during build process.
 src/assets/*.wasm
 src/assets/wasm_exec.js
+wasm/stdlib/stdlib.bundle

--- a/README.md
+++ b/README.md
@@ -69,8 +69,9 @@ npm install
 npm run dev
 ```
 
-The `predev` script compiles the Go analyzer in [`wasm`](./wasm) to WebAssembly
-and copies Go's `wasm_exec.js` runtime into the frontend automatically.
+The `predev` script generates the bundled standard-library type data, compiles
+the Go analyzer in [`wasm`](./wasm) to WebAssembly, and copies Go's
+`wasm_exec.js` runtime into the frontend automatically.
 
 If you change the Go code, restart the development server so the WebAssembly
 module is rebuilt.

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "predev": "cd wasm && GOOS=js GOARCH=wasm go build -o ../src/assets/goggle.wasm && cp \"$(go env GOROOT)/lib/wasm/wasm_exec.js\" ../src/assets",
+    "build:wasm": "cd wasm && go generate ./... && GOOS=js GOARCH=wasm go build -o ../src/assets/goggle.wasm && cp \"$(go env GOROOT)/lib/wasm/wasm_exec.js\" ../src/assets",
+    "predev": "npm run build:wasm",
     "dev": "vite",
-    "prebuild": "cd wasm && GOOS=js GOARCH=wasm go build -o ../src/assets/goggle.wasm && cp \"$(go env GOROOT)/lib/wasm/wasm_exec.js\" ../src/assets",
+    "prebuild": "npm run build:wasm",
     "build": "tsc -b && vite build",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"

--- a/wasm/cmd/genstdlib/main.go
+++ b/wasm/cmd/genstdlib/main.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"go/token"
+	"go/types"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+
+	"github.com/yuxincs/goggle/stdlib/bundle"
+	"golang.org/x/tools/go/gcexportdata"
+)
+
+type listedPackage struct {
+	ImportPath string
+	Export     string
+}
+
+func main() {
+	output := flag.String("output", "stdlib.bundle", "path to the generated standard library bundle")
+	flag.Parse()
+
+	packages, err := listStandardLibrary()
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := writeBundle(*output, packages); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func listStandardLibrary() ([]listedPackage, error) {
+	command := exec.Command("go", "list", "-e", "-export", "-trimpath", "-json", "std")
+	command.Env = targetEnvironment(os.Environ())
+	output, err := command.Output()
+	if err != nil {
+		return nil, fmt.Errorf("list standard library: %w", err)
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(output))
+	packages := make([]listedPackage, 0)
+	for {
+		var pkg listedPackage
+		err := decoder.Decode(&pkg)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("decode package list: %w", err)
+		}
+		if pkg.ImportPath != "" && pkg.Export != "" && isPublicPackage(pkg.ImportPath) {
+			packages = append(packages, pkg)
+		}
+	}
+	sort.Slice(packages, func(left, right int) bool {
+		return packages[left].ImportPath < packages[right].ImportPath
+	})
+	return packages, nil
+}
+
+func isPublicPackage(importPath string) bool {
+	for _, component := range strings.Split(importPath, "/") {
+		if component == "internal" || component == "vendor" {
+			return false
+		}
+	}
+	return true
+}
+
+func targetEnvironment(environment []string) []string {
+	target := make([]string, 0, len(environment)+3)
+	for _, value := range environment {
+		if strings.HasPrefix(value, "GOOS=") ||
+			strings.HasPrefix(value, "GOARCH=") ||
+			strings.HasPrefix(value, "CGO_ENABLED=") {
+			continue
+		}
+		target = append(target, value)
+	}
+	return append(target, "GOOS=js", "GOARCH=wasm", "CGO_ENABLED=0")
+}
+
+func writeBundle(output string, packages []listedPackage) (returnError error) {
+	directory := filepath.Dir(output)
+	if err := os.MkdirAll(directory, 0o755); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+	temporary, err := os.CreateTemp(directory, ".stdlib-*.bundle")
+	if err != nil {
+		return fmt.Errorf("create temporary bundle: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	defer temporary.Close()
+	defer func() {
+		if err := os.Remove(temporaryPath); err != nil && !os.IsNotExist(err) && returnError == nil {
+			returnError = fmt.Errorf("remove temporary bundle: %w", err)
+		}
+	}()
+
+	fset := token.NewFileSet()
+	entries := make([]bundle.Entry, 0, len(packages))
+	for _, pkg := range packages {
+		definition, err := readPackageDefinition(fset, pkg)
+		if err != nil {
+			return fmt.Errorf("read %s export data: %w", pkg.ImportPath, err)
+		}
+		entries = append(entries, bundle.Entry{Path: pkg.ImportPath, Data: definition})
+	}
+	encoded, err := bundle.Marshal(runtime.Version(), entries)
+	if err != nil {
+		return fmt.Errorf("encode bundle: %w", err)
+	}
+	if _, err := temporary.Write(encoded); err != nil {
+		return fmt.Errorf("write bundle: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close temporary bundle: %w", err)
+	}
+	if err := os.Chmod(temporaryPath, 0o644); err != nil {
+		return fmt.Errorf("set bundle permissions: %w", err)
+	}
+	if err := os.Rename(temporaryPath, output); err != nil {
+		return fmt.Errorf("install bundle: %w", err)
+	}
+	return nil
+}
+
+func readPackageDefinition(
+	fset *token.FileSet,
+	pkg listedPackage,
+) ([]byte, error) {
+	file, err := os.Open(pkg.Export)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	reader, err := gcexportdata.NewReader(file)
+	if err != nil {
+		return nil, err
+	}
+	typesPackage, err := gcexportdata.Read(
+		reader,
+		fset,
+		make(map[string]*types.Package),
+		pkg.ImportPath,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var definition bytes.Buffer
+	if err := gcexportdata.Write(&definition, fset, typesPackage); err != nil {
+		return nil, err
+	}
+	return definition.Bytes(), nil
+}

--- a/wasm/ssa/ssa.go
+++ b/wasm/ssa/ssa.go
@@ -2,13 +2,13 @@ package ssa
 
 import (
 	goast "go/ast"
-	"go/importer"
 	"go/token"
 	"go/types"
 	"reflect"
 	"strings"
 
 	"github.com/yuxincs/goggle/source"
+	"github.com/yuxincs/goggle/stdlib"
 	toolsssa "golang.org/x/tools/go/ssa"
 	"golang.org/x/tools/go/ssa/ssautil"
 )
@@ -45,9 +45,13 @@ type Function struct {
 }
 
 func Analyze(fset *token.FileSet, file *goast.File) ([]*Function, error) {
+	typesImporter, err := stdlib.NewImporter(fset)
+	if err != nil {
+		return nil, err
+	}
 	pkg := types.NewPackage("main", "")
 	ssaPkg, typesInfo, err := ssautil.BuildPackage(
-		&types.Config{Importer: importer.Default()},
+		&types.Config{Importer: typesImporter},
 		fset,
 		pkg,
 		[]*goast.File{file},

--- a/wasm/ssa/ssa_test.go
+++ b/wasm/ssa/ssa_test.go
@@ -5,6 +5,7 @@ import (
 	"go/parser"
 	"go/token"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,20 +14,30 @@ import (
 )
 
 func TestAnalyzeGolden(t *testing.T) {
-	fset := token.NewFileSet()
-	inputPath := filepath.Join("testdata", "foo.input.go")
-	file, err := parser.ParseFile(fset, inputPath, nil, parser.ParseComments)
-	require.NoError(t, err, "parse input")
+	inputPaths, err := filepath.Glob(filepath.Join("testdata", "*.input.go"))
+	require.NoError(t, err, "discover input files")
+	require.Positive(t, len(inputPaths), "no SSA fixtures matching testdata/*.input.go were found")
 
-	actualResult, err := ssaanalysis.Analyze(fset, file)
-	require.NoError(t, err, "analyze SSA")
-	actual, err := json.MarshalIndent(actualResult, "", "  ")
-	require.NoError(t, err, "marshal SSA")
-	actual = append(actual, '\n')
+	for _, inputPath := range inputPaths {
+		name := strings.TrimSuffix(filepath.Base(inputPath), ".input.go")
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-	goggletest.AssertGolden(
-		t,
-		filepath.Join("testdata", "foo.expected.json"),
-		actual,
-	)
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, inputPath, nil, parser.ParseComments)
+			require.NoError(t, err, "parse input")
+
+			actualResult, err := ssaanalysis.Analyze(fset, file)
+			require.NoError(t, err, "analyze SSA")
+			actual, err := json.MarshalIndent(actualResult, "", "  ")
+			require.NoError(t, err, "marshal SSA")
+			actual = append(actual, '\n')
+
+			goggletest.AssertGolden(
+				t,
+				strings.TrimSuffix(inputPath, ".input.go")+".expected.json",
+				actual,
+			)
+		})
+	}
 }

--- a/wasm/ssa/testdata/imports.expected.json
+++ b/wasm/ssa/testdata/imports.expected.json
@@ -1,0 +1,72 @@
+[
+  {
+    "name": "exported",
+    "signature": "func(name string) bool",
+    "position": {
+      "offset": 38,
+      "line": 5,
+      "column": 6
+    },
+    "parameters": [
+      {
+        "name": "name",
+        "type": "string",
+        "text": "parameter name : string"
+      }
+    ],
+    "blocks": [
+      {
+        "index": 0,
+        "comment": "entry",
+        "predecessors": [],
+        "successors": [],
+        "instructions": [
+          {
+            "index": 0,
+            "opcode": "Call",
+            "text": "go/ast.IsExported(name)",
+            "position": {
+              "offset": 89,
+              "line": 6,
+              "column": 23
+            },
+            "result": {
+              "name": "t0",
+              "type": "bool",
+              "text": "go/ast.IsExported(name)"
+            },
+            "operands": [
+              {
+                "name": "IsExported",
+                "type": "func(name string) bool",
+                "text": "go/ast.IsExported"
+              },
+              {
+                "name": "name",
+                "type": "string",
+                "text": "parameter name : string"
+              }
+            ]
+          },
+          {
+            "index": 1,
+            "opcode": "Return",
+            "text": "return t0",
+            "position": {
+              "offset": 68,
+              "line": 6,
+              "column": 2
+            },
+            "operands": [
+              {
+                "name": "t0",
+                "type": "bool",
+                "text": "go/ast.IsExported(name)"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/wasm/ssa/testdata/imports.input.go
+++ b/wasm/ssa/testdata/imports.input.go
@@ -1,0 +1,7 @@
+package sample
+
+import "go/ast"
+
+func exported(name string) bool {
+	return ast.IsExported(name)
+}

--- a/wasm/stdlib/bundle/bundle.go
+++ b/wasm/stdlib/bundle/bundle.go
@@ -1,0 +1,160 @@
+// Package bundle encodes and indexes standard-library export data.
+package bundle
+
+import "errors"
+
+const (
+	magic      = "GGLSTDL1"
+	headerSize = len(magic) + 2
+)
+
+// A bundle starts with the magic value, a uint16 Go version length, the Go
+// version, and a uint32 package count. Each index entry contains a uint16 path
+// length, the path, and uint32 payload offset and length values. All integers
+// are little-endian. The indexed export-data payloads follow the complete index.
+
+type Entry struct {
+	Path string
+	Data []byte
+}
+
+type Bundle struct {
+	GoVersion string
+	Entries   map[string][]byte
+}
+
+func Marshal(goVersion string, entries []Entry) ([]byte, error) {
+	if goVersion == "" {
+		return nil, errors.New("Go version is empty")
+	}
+	if uint64(len(goVersion)) > uint64(^uint16(0)) {
+		return nil, errors.New("Go version is too long")
+	}
+	indexSize := uint64(headerSize + len(goVersion) + 4)
+	payloadSize := uint64(0)
+	for _, entry := range entries {
+		if entry.Path == "" {
+			return nil, errors.New("package path is empty")
+		}
+		if uint64(len(entry.Path)) > uint64(^uint16(0)) {
+			return nil, errors.New("package path is too long")
+		}
+		if uint64(len(entry.Data)) > uint64(^uint32(0)) {
+			return nil, errors.New("package export data is too large")
+		}
+		indexSize += uint64(2 + len(entry.Path) + 4 + 4)
+		payloadSize += uint64(len(entry.Data))
+		if indexSize > uint64(^uint32(0)) || payloadSize > uint64(^uint32(0))-indexSize {
+			return nil, errors.New("standard library bundle is too large")
+		}
+	}
+	if uint64(len(entries)) > uint64(^uint32(0)) {
+		return nil, errors.New("too many packages in standard library bundle")
+	}
+
+	bundle := make([]byte, int(indexSize+payloadSize))
+	copy(bundle, magic)
+	putUint16(bundle[len(magic):], uint16(len(goVersion)))
+	copy(bundle[headerSize:], goVersion)
+	putUint32(bundle[headerSize+len(goVersion):], uint32(len(entries)))
+
+	indexOffset := headerSize + len(goVersion) + 4
+	payloadOffset := int(indexSize)
+	for _, entry := range entries {
+		putUint16(bundle[indexOffset:], uint16(len(entry.Path)))
+		indexOffset += 2
+		copy(bundle[indexOffset:], entry.Path)
+		indexOffset += len(entry.Path)
+		putUint32(bundle[indexOffset:], uint32(payloadOffset))
+		indexOffset += 4
+		putUint32(bundle[indexOffset:], uint32(len(entry.Data)))
+		indexOffset += 4
+		copy(bundle[payloadOffset:], entry.Data)
+		payloadOffset += len(entry.Data)
+	}
+	return bundle, nil
+}
+
+func Parse(bundle []byte) (*Bundle, error) {
+	if len(bundle) < headerSize || string(bundle[:len(magic)]) != magic {
+		return nil, errors.New("invalid standard library bundle header")
+	}
+	goVersionSize := int(readUint16(bundle[len(magic):]))
+	if goVersionSize == 0 || len(bundle)-headerSize < goVersionSize+4 {
+		return nil, errors.New("invalid standard library bundle Go version")
+	}
+	goVersion := string(bundle[headerSize : headerSize+goVersionSize])
+
+	type descriptor struct {
+		path   string
+		offset uint32
+		size   uint32
+	}
+	indexOffset := headerSize + goVersionSize
+	count := uint64(readUint32(bundle[indexOffset:]))
+	indexOffset += 4
+	if count > uint64((len(bundle)-indexOffset)/10) {
+		return nil, errors.New("invalid standard library bundle package count")
+	}
+	descriptors := make([]descriptor, 0, int(count))
+	for range count {
+		if len(bundle)-indexOffset < 2 {
+			return nil, errors.New("truncated standard library bundle index")
+		}
+		pathSize := int(readUint16(bundle[indexOffset:]))
+		indexOffset += 2
+		if pathSize == 0 || len(bundle)-indexOffset < pathSize+8 {
+			return nil, errors.New("invalid standard library bundle index entry")
+		}
+		path := string(bundle[indexOffset : indexOffset+pathSize])
+		indexOffset += pathSize
+		offset := readUint32(bundle[indexOffset:])
+		indexOffset += 4
+		size := readUint32(bundle[indexOffset:])
+		indexOffset += 4
+		descriptors = append(descriptors, descriptor{path: path, offset: offset, size: size})
+	}
+
+	entries := make(map[string][]byte, len(descriptors))
+	payloadOffset := uint64(indexOffset)
+	for _, descriptor := range descriptors {
+		if payloadOffset > uint64(len(bundle)) ||
+			uint64(descriptor.offset) != payloadOffset ||
+			uint64(descriptor.size) > uint64(len(bundle))-payloadOffset {
+			return nil, errors.New("invalid standard library bundle payload")
+		}
+		if _, duplicate := entries[descriptor.path]; duplicate {
+			return nil, errors.New("duplicate package in standard library bundle")
+		}
+		payloadEnd := payloadOffset + uint64(descriptor.size)
+		entries[descriptor.path] = bundle[payloadOffset:payloadEnd]
+		payloadOffset = payloadEnd
+	}
+	if payloadOffset != uint64(len(bundle)) {
+		return nil, errors.New("unexpected data at end of standard library bundle")
+	}
+	return &Bundle{GoVersion: goVersion, Entries: entries}, nil
+}
+
+func putUint16(destination []byte, value uint16) {
+	destination[0] = byte(value)
+	destination[1] = byte(value >> 8)
+}
+
+func putUint32(destination []byte, value uint32) {
+	destination[0] = byte(value)
+	destination[1] = byte(value >> 8)
+	destination[2] = byte(value >> 16)
+	destination[3] = byte(value >> 24)
+}
+
+func readUint16(source []byte) uint16 {
+	return uint16(source[0]) | uint16(source[1])<<8
+}
+
+func readUint32(source []byte) uint32 {
+	return uint32(source[0]) |
+		uint32(source[1])<<8 |
+		uint32(source[2])<<16 |
+		uint32(source[3])<<24
+}

--- a/wasm/stdlib/bundle/bundle_test.go
+++ b/wasm/stdlib/bundle/bundle_test.go
@@ -1,0 +1,31 @@
+package bundle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	entries := []Entry{
+		{Path: "bytes", Data: []byte("bytes export data")},
+		{Path: "go/ast", Data: []byte("ast export data")},
+	}
+	bundle, err := Marshal("go1.26", entries)
+	require.NoError(t, err, "marshal bundle")
+	actual, err := Parse(bundle)
+	require.NoError(t, err, "parse bundle")
+	require.Equal(t, "go1.26", actual.GoVersion)
+	for _, entry := range entries {
+		require.Equal(t, entry.Data, actual.Entries[entry.Path], "entry %q", entry.Path)
+	}
+}
+
+func TestParseRejectsInvalidBundle(t *testing.T) {
+	t.Parallel()
+
+	_, err := Parse([]byte("not a bundle"))
+	require.Error(t, err)
+}

--- a/wasm/stdlib/importer.go
+++ b/wasm/stdlib/importer.go
@@ -1,0 +1,64 @@
+package stdlib
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"go/token"
+	"go/types"
+	"sync"
+
+	"github.com/yuxincs/goggle/stdlib/bundle"
+	"golang.org/x/tools/go/gcexportdata"
+)
+
+//go:generate go run ../cmd/genstdlib -output stdlib.bundle
+
+//go:embed stdlib.bundle
+var bundleData []byte
+
+var (
+	bundleOnce    sync.Once
+	bundleEntries map[string][]byte
+	bundleError   error
+)
+
+func NewImporter(fset *token.FileSet) (types.Importer, error) {
+	bundleOnce.Do(loadBundle)
+	if bundleError != nil {
+		return nil, bundleError
+	}
+
+	return &bundleImporter{
+		fset:     fset,
+		packages: make(map[string]*types.Package),
+	}, nil
+}
+
+type bundleImporter struct {
+	fset     *token.FileSet
+	packages map[string]*types.Package
+}
+
+func (current *bundleImporter) Import(path string) (*types.Package, error) {
+	if path == "unsafe" {
+		return types.Unsafe, nil
+	}
+	if pkg := current.packages[path]; pkg != nil && pkg.Complete() {
+		return pkg, nil
+	}
+	definition, ok := bundleEntries[path]
+	if !ok {
+		return nil, fmt.Errorf("package %q is not available in the bundled Go standard library", path)
+	}
+	return gcexportdata.Read(bytes.NewReader(definition), current.fset, current.packages, path)
+}
+
+func loadBundle() {
+	parsed, err := bundle.Parse(bundleData)
+	if err != nil {
+		bundleError = fmt.Errorf("open bundled Go standard library: %w", err)
+		return
+	}
+	bundleEntries = parsed.Entries
+}


### PR DESCRIPTION
Generate a compact indexed bundle of standard-library export data during builds and use it to resolve SSA imports in the browser. Add import golden coverage and generate the asset in CI.\n\nValidated with native and WASM Go tests, go vet, ESLint, and a production build.