### PR TITLE
Define the frontend WASM boundary

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { KeyboardEvent, PointerEvent, useEffect, useRef, useState } from "react";
 import { IPosition } from "monaco-editor";
-import { loadGoggleWasm } from "./utils/wasm.ts";
+import { loadGoggleWasm, parseGoSource } from "./wasm/client.ts";
 import { ASTViewer } from "./viewers/ast/ASTViewer.tsx";
 import { CFGViewer } from "./viewers/cfg/CFGViewer.tsx";
 import { SSAViewer } from "./viewers/ssa/SSAViewer.tsx";
@@ -11,7 +11,7 @@ import {
   ASTNode,
   CFGFunction,
   SSAFunction,
-} from "./analysis.ts";
+} from "./wasm/protocol.ts";
 
 // We store the Go source and the last cursor position in local storage such that users will not lose their input.
 const defaultCode = `// You can edit this code!
@@ -98,15 +98,13 @@ export const App = () => {
       return;
     }
 
-    // @ts-expect-error: `parse` is injected into global this by the Goggle WebAssembly module.
-    if (globalThis.parse === undefined) {
+    const result = parseGoSource(code);
+    if (result === undefined) {
       renderError("WASM: Go wasm may not have been initialized yet");
       return;
     }
     setSrc(code);
 
-    // @ts-expect-error: `parse` is injected into global this by the Goggle WebAssembly module.
-    const result = globalThis.parse(code);
     if (result.error !== undefined) {
       renderError(result.error);
       return;

--- a/src/viewers/ast/ASTViewer.tsx
+++ b/src/viewers/ast/ASTViewer.tsx
@@ -2,7 +2,7 @@ import { CodeViewer } from "../CodeViewer.tsx";
 import React, { useMemo } from "react";
 import { ViewerTitle } from "../ViewerTitle.tsx";
 import { VIEWER_TITLE_HEIGHT } from "../../constants.ts";
-import { ASTNode } from "../../analysis.ts";
+import { ASTNode } from "../../wasm/protocol.ts";
 import { formatAST } from "./format.ts";
 import {
   displayLineForSourceLine,

--- a/src/viewers/ast/format.ts
+++ b/src/viewers/ast/format.ts
@@ -1,4 +1,4 @@
-import { ASTNode, SourceRange } from "../../analysis.ts";
+import { ASTNode, SourceRange } from "../../wasm/protocol.ts";
 import { FormattedAnalysis } from "../lineMapping.ts";
 
 const formatPosition = (line: number, column: number) => `${line}:${column}`;

--- a/src/viewers/cfg/CFGViewer.tsx
+++ b/src/viewers/cfg/CFGViewer.tsx
@@ -2,7 +2,7 @@ import { CodeViewer } from "../CodeViewer.tsx";
 import React, { useMemo } from "react";
 import { ViewerTitle } from "../ViewerTitle.tsx";
 import { VIEWER_TITLE_HEIGHT } from "../../constants.ts";
-import { CFGFunction } from "../../analysis.ts";
+import { CFGFunction } from "../../wasm/protocol.ts";
 import { formatCFGs } from "./format.ts";
 import {
   displayLineForSourceLine,

--- a/src/viewers/cfg/format.ts
+++ b/src/viewers/cfg/format.ts
@@ -1,4 +1,4 @@
-import { CFGFunction, SourceRange } from "../../analysis.ts";
+import { CFGFunction, SourceRange } from "../../wasm/protocol.ts";
 import { FormattedAnalysis } from "../lineMapping.ts";
 
 const formatPosition = (line: number, column: number) => `${line}:${column}`;

--- a/src/viewers/ssa/SSAViewer.tsx
+++ b/src/viewers/ssa/SSAViewer.tsx
@@ -2,7 +2,7 @@ import { CodeViewer } from "../CodeViewer.tsx";
 import React, { useMemo } from "react";
 import { ViewerTitle } from "../ViewerTitle.tsx";
 import { VIEWER_TITLE_HEIGHT } from "../../constants.ts";
-import { SSAFunction } from "../../analysis.ts";
+import { SSAFunction } from "../../wasm/protocol.ts";
 import { formatSSA } from "./format.ts";
 import {
   displayLineForSourceLine,

--- a/src/viewers/ssa/format.ts
+++ b/src/viewers/ssa/format.ts
@@ -1,4 +1,4 @@
-import { SourcePosition, SSAFunction } from "../../analysis.ts";
+import { SourcePosition, SSAFunction } from "../../wasm/protocol.ts";
 import { FormattedAnalysis } from "../lineMapping.ts";
 
 const formatPosition = (position: SourcePosition) =>

--- a/src/wasm/client.ts
+++ b/src/wasm/client.ts
@@ -1,11 +1,11 @@
 import "../assets/wasm_exec.js";
 import goggleWasm from "../assets/goggle.wasm?url";
+import type { WasmParseResult } from "./protocol.ts";
 
 const PARSER_TIMEOUT = 30_000;
 let loadPromise: Promise<void> | undefined;
 
 const isParserReady = () => {
-  // @ts-expect-error: `parse` is injected into global this by the Goggle WebAssembly module.
   return typeof globalThis.parse === "function";
 };
 
@@ -32,7 +32,6 @@ const initializeGoggleWasm = async () => {
     return;
   }
 
-  // @ts-expect-error: `Go` is imported in global this by `wasm_exec.js` file.
   const go = new Go();
   const result = await WebAssembly.instantiateStreaming(
     fetch(goggleWasm),
@@ -53,4 +52,8 @@ export const loadGoggleWasm = () => {
     });
   }
   return loadPromise;
+};
+
+export const parseGoSource = (source: string): WasmParseResult | undefined => {
+  return globalThis.parse?.(source);
 };

--- a/src/wasm/protocol.ts
+++ b/src/wasm/protocol.ts
@@ -80,3 +80,7 @@ export interface AnalysisResult {
   cfgs: CFGFunction[];
   ssa: SSAFunction[];
 }
+
+export type WasmParseResult =
+  | { body: string; error?: undefined }
+  | { body?: undefined; error: string };

--- a/src/wasm/runtime.d.ts
+++ b/src/wasm/runtime.d.ts
@@ -1,0 +1,16 @@
+import type { WasmParseResult } from "./protocol.ts";
+
+declare global {
+  interface GoRuntime {
+    importObject: WebAssembly.Imports;
+    run(instance: WebAssembly.Instance): Promise<void>;
+  }
+
+  var Go: {
+    new (): GoRuntime;
+  };
+
+  var parse: ((source: string) => WasmParseResult) | undefined;
+}
+
+export {};


### PR DESCRIPTION
Group the WASM client, protocol types, and runtime globals under src/wasm. Keep injected Go globals behind the typed client and remove the related TypeScript suppressions.\n\nValidated with TypeScript 7, ESLint, and a production build.