### PR TITLE
Extract the Go analyzer package

### DIFF
--- a/wasm/analyzer/analyzer.go
+++ b/wasm/analyzer/analyzer.go
@@ -1,4 +1,4 @@
-package main
+package analyzer
 
 import (
 	"fmt"
@@ -16,7 +16,7 @@ type Result struct {
 	SSA  []*ssaanalysis.Function `json:"ssa"`
 }
 
-func parse(src string) (*Result, error) {
+func Analyze(src string) (*Result, error) {
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, "main.go", src, parser.ParseComments)
 	if err != nil {

--- a/wasm/analyzer/analyzer_test.go
+++ b/wasm/analyzer/analyzer_test.go
@@ -1,0 +1,25 @@
+package analyzer_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yuxincs/goggle/analyzer"
+)
+
+func TestAnalyze(t *testing.T) {
+	t.Parallel()
+
+	result, err := analyzer.Analyze(`package main
+
+func main() {
+	println("hello")
+}
+`)
+	require.NoError(t, err)
+	require.Equal(t, "File", result.AST.Type)
+	require.Len(t, result.CFGs, 1)
+	require.Equal(t, "main", result.CFGs[0].Name)
+	require.Len(t, result.SSA, 1)
+	require.Equal(t, "main", result.SSA[0].Name)
+}

--- a/wasm/main.go
+++ b/wasm/main.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"syscall/js"
+
+	"github.com/yuxincs/goggle/analyzer"
 )
 
 func main() {
@@ -29,7 +31,7 @@ func main() {
 			})
 		}
 
-		result, err := parse(args[0].String())
+		result, err := analyzer.Analyze(args[0].String())
 		if err != nil {
 			return js.ValueOf(map[string]interface{}{
 				"error": err.Error(),


### PR DESCRIPTION
Moves analysis orchestration out of the WASM entrypoint into a reusable analyzer package. Adds a focused package test for the combined AST, CFG, and SSA result.

Checks:
- go test ./...
- GOOS=js GOARCH=wasm go test -exec=... ./...
- go vet ./...
- npm run build