### PR TITLE
Run Go WebAssembly in a worker

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -47,20 +47,21 @@ export const App = () => {
   const [leftRowSplit, setLeftRowSplit] = useState(50);
   const [rightRowSplit, setRightRowSplit] = useState(50);
   const workspaceRef = useRef<HTMLElement>(null);
+  const analysisVersionRef = useRef(0);
 
   const [ast, setAST] = useState<ASTNode | string | null>(null);
   const [cfgs, setCFGs] = useState<CFGFunction[] | string | null>(null);
   const [ssa, setSSA] = useState<SSAFunction[] | string | null>(null);
 
-  // Start Go WebAssembly such that the parse function is available in global this.
-  // Then, load the source and position from local storage and set then.
+  // Start Go WebAssembly in its worker, then restore the source and position.
   useEffect(() => {
     let isCurrent = true;
 
     loadGoggleWasm()
-      .then(() => {
+      .then(async () => {
         if (!isCurrent) return;
-        handleSrcChange(storedSrc);
+        await handleSrcChange(storedSrc);
+        if (!isCurrent) return;
         handleSrcPosChange(storedPos);
         setIsReady(true);
       })
@@ -86,8 +87,10 @@ export const App = () => {
   }, [srcPos]);
   useEffect(() => localStorage.setItem("theme", theme), [theme]);
 
-  function handleSrcChange(code: string | undefined) {
+  async function handleSrcChange(code: string | undefined) {
+    const version = ++analysisVersionRef.current;
     const renderError = (error: string) => {
+      if (version !== analysisVersionRef.current) return;
       setAST(`ERROR: ${error}`);
       setCFGs(`ERROR: ${error}`);
       setSSA(`ERROR: ${error}`);
@@ -98,12 +101,16 @@ export const App = () => {
       return;
     }
 
-    const result = parseGoSource(code);
-    if (result === undefined) {
-      renderError("WASM: Go wasm may not have been initialized yet");
+    setSrc(code);
+
+    let result;
+    try {
+      result = await parseGoSource(code);
+    } catch (error: unknown) {
+      renderError(error instanceof Error ? error.message : String(error));
       return;
     }
-    setSrc(code);
+    if (version !== analysisVersionRef.current) return;
 
     if (result.error !== undefined) {
       renderError(result.error);
@@ -212,7 +219,7 @@ export const App = () => {
             <SourceEditor
               initialContent={src}
               position={srcPos}
-              onChange={handleSrcChange}
+              onChange={(code) => void handleSrcChange(code)}
               onCursorChange={(event) => handleSrcPosChange(event.position)}
               onReady={() => setIsSourceReady(true)}
               theme={theme}

--- a/src/wasm/client.ts
+++ b/src/wasm/client.ts
@@ -1,59 +1,58 @@
-import "./generated/wasm_exec.js";
-import goggleWasm from "./generated/goggle.wasm?url";
 import type { WasmParseResult } from "./protocol.ts";
+import type {
+  WorkerMethod,
+  WorkerRequest,
+  WorkerRequestMap,
+  WorkerResponse,
+  WorkerResultMap,
+} from "./workerProtocol.ts";
 
-const PARSER_TIMEOUT = 30_000;
-let loadPromise: Promise<void> | undefined;
+const worker = new Worker(new URL("./worker.ts", import.meta.url), {
+  type: "module",
+});
+const pendingRequests = new Map<
+  number,
+  { resolve: (result: unknown) => void; reject: (error: Error) => void }
+>();
+let nextRequestID = 1;
 
-const isParserReady = () => {
-  return typeof globalThis.parse === "function";
-};
+worker.addEventListener("message", (event: MessageEvent<WorkerResponse>) => {
+  const response = event.data;
+  const pending = pendingRequests.get(response.id);
+  if (pending === undefined) return;
 
-const waitForParser = () => new Promise<void>((resolve, reject) => {
-  const deadline = performance.now() + PARSER_TIMEOUT;
-
-  const check = () => {
-    if (isParserReady()) {
-      resolve();
-      return;
-    }
-    if (performance.now() >= deadline) {
-      reject(new Error("Go WebAssembly parser initialization timed out"));
-      return;
-    }
-    window.setTimeout(check, 10);
-  };
-
-  check();
+  pendingRequests.delete(response.id);
+  if (response.error !== undefined) {
+    pending.reject(new Error(response.error));
+  } else {
+    pending.resolve(response.result);
+  }
 });
 
-const initializeGoggleWasm = async () => {
-  if (isParserReady()) {
-    return;
-  }
+worker.addEventListener("error", (event) => {
+  const error = new Error(event.message || "Go WebAssembly worker failed");
+  for (const pending of pendingRequests.values()) pending.reject(error);
+  pendingRequests.clear();
+});
 
-  const go = new Go();
-  const result = await WebAssembly.instantiateStreaming(
-    fetch(goggleWasm),
-    go.importObject
-  );
-  console.log("Go WebAssembly started");
-
-  // Run the instance without waiting since Go Assembly would be running forever to provide the functionality.
-  void go.run(result.instance);
-  await waitForParser();
-};
-
-export const loadGoggleWasm = () => {
-  if (loadPromise === undefined) {
-    loadPromise = initializeGoggleWasm().catch((error) => {
-      loadPromise = undefined;
-      throw error;
+const request = <Method extends WorkerMethod>(
+  method: Method,
+  params: WorkerRequestMap[Method],
+) => {
+  const id = nextRequestID++;
+  const message = { id, method, params } as WorkerRequest;
+  return new Promise<WorkerResultMap[Method]>((resolve, reject) => {
+    pendingRequests.set(id, {
+      resolve: (result) => resolve(result as WorkerResultMap[Method]),
+      reject,
     });
-  }
-  return loadPromise;
+    worker.postMessage(message);
+  });
 };
 
-export const parseGoSource = (source: string): WasmParseResult | undefined => {
-  return globalThis.parse?.(source);
+export const loadGoggleWasm = async () => {
+  await request("initialize", undefined);
 };
+
+export const parseGoSource = (source: string): Promise<WasmParseResult> =>
+  request("analyze", { source });

--- a/src/wasm/worker.ts
+++ b/src/wasm/worker.ts
@@ -1,0 +1,82 @@
+/// <reference lib="webworker" />
+
+import "./generated/wasm_exec.js";
+import goggleWasm from "./generated/goggle.wasm?url";
+import type { WasmParseResult } from "./protocol.ts";
+import type { WorkerRequest, WorkerResponse } from "./workerProtocol.ts";
+
+const PARSER_TIMEOUT = 30_000;
+let loadPromise: Promise<void> | undefined;
+
+const isParserReady = () => typeof globalThis.parse === "function";
+
+const waitForParser = () => new Promise<void>((resolve, reject) => {
+  const deadline = performance.now() + PARSER_TIMEOUT;
+
+  const check = () => {
+    if (isParserReady()) {
+      resolve();
+      return;
+    }
+    if (performance.now() >= deadline) {
+      reject(new Error("Go WebAssembly parser initialization timed out"));
+      return;
+    }
+    setTimeout(check, 10);
+  };
+
+  check();
+});
+
+const initializeGoggleWasm = async () => {
+  if (isParserReady()) return;
+
+  const go = new Go();
+  const result = await WebAssembly.instantiateStreaming(
+    fetch(goggleWasm),
+    go.importObject,
+  );
+
+  // The Go program deliberately runs forever while it serves requests.
+  void go.run(result.instance);
+  await waitForParser();
+};
+
+const loadGoggleWasm = () => {
+  if (loadPromise === undefined) {
+    loadPromise = initializeGoggleWasm().catch((error) => {
+      loadPromise = undefined;
+      throw error;
+    });
+  }
+  return loadPromise;
+};
+
+const analyze = async (source: string): Promise<WasmParseResult> => {
+  await loadGoggleWasm();
+  const result = globalThis.parse?.(source);
+  if (result === undefined) {
+    throw new Error("Go WebAssembly parser is unavailable");
+  }
+  return result;
+};
+
+self.addEventListener("message", (event: MessageEvent<WorkerRequest>) => {
+  const request = event.data;
+
+  void (async () => {
+    try {
+      const result = request.method === "initialize"
+        ? await loadGoggleWasm().then(() => null)
+        : await analyze(request.params.source);
+      const response: WorkerResponse = { id: request.id, result };
+      self.postMessage(response);
+    } catch (error: unknown) {
+      const response: WorkerResponse = {
+        id: request.id,
+        error: error instanceof Error ? error.message : String(error),
+      };
+      self.postMessage(response);
+    }
+  })();
+});

--- a/src/wasm/workerProtocol.ts
+++ b/src/wasm/workerProtocol.ts
@@ -1,0 +1,25 @@
+import type { WasmParseResult } from "./protocol.ts";
+
+export interface WorkerRequestMap {
+  initialize: undefined;
+  analyze: { source: string };
+}
+
+export interface WorkerResultMap {
+  initialize: null;
+  analyze: WasmParseResult;
+}
+
+export type WorkerMethod = keyof WorkerRequestMap;
+
+export type WorkerRequest = {
+  [Method in WorkerMethod]: {
+    id: number;
+    method: Method;
+    params: WorkerRequestMap[Method];
+  };
+}[WorkerMethod];
+
+export type WorkerResponse =
+  | { id: number; result: unknown; error?: undefined }
+  | { id: number; result?: undefined; error: string };


### PR DESCRIPTION
Moves Go WebAssembly initialization and analysis into a module worker. The frontend now uses asynchronous request/response messaging and ignores stale analysis results.\n\nChecks:\n- npm run lint\n- npm run build