### PR TITLE
Add Go completion support

### DIFF
--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -5,6 +5,9 @@ import "../index.css";
 import "@fontsource/inter";
 import "@fontsource/jetbrains-mono";
 import "@fontsource/jetbrains-mono/800.css";
+import { registerGoIDE } from "../editor/ide.ts";
+
+registerGoIDE();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/src/editor/SourceEditor.tsx
+++ b/src/editor/SourceEditor.tsx
@@ -2,6 +2,7 @@ import { CodeViewer } from "../viewers/shared/CodeViewer.tsx";
 import { editor, IPosition } from "monaco-editor";
 import { ViewerTitle } from "../viewers/shared/ViewerTitle.tsx";
 import { VIEWER_TITLE_HEIGHT } from "../constants.ts";
+import { GO_SOURCE_URI } from "./ide.ts";
 
 interface SourceEditorProps {
   onChange: (code: string | undefined) => void;
@@ -17,6 +18,7 @@ export const SourceEditor = (props: SourceEditorProps) => {
     <>
       <ViewerTitle sx={{ height: VIEWER_TITLE_HEIGHT }}>Go Source</ViewerTitle>
       <CodeViewer
+        path={GO_SOURCE_URI}
         initialContent={props.initialContent}
         initialLine={props.position.lineNumber}
         line={props.position.lineNumber}

--- a/src/editor/ide.ts
+++ b/src/editor/ide.ts
@@ -1,0 +1,78 @@
+import { languages, Range, type editor } from "monaco-editor";
+import type {
+  IDECompletionKind,
+  IDEDocumentPosition,
+  IDERange,
+} from "../wasm/protocol.ts";
+import { completeGo, updateIDEDocument } from "../wasm/client.ts";
+
+export const GO_SOURCE_URI = "file:///main.go";
+
+const completionKinds: Record<
+  IDECompletionKind,
+  languages.CompletionItemKind
+> = {
+  constant: languages.CompletionItemKind.Constant,
+  field: languages.CompletionItemKind.Field,
+  function: languages.CompletionItemKind.Function,
+  keyword: languages.CompletionItemKind.Keyword,
+  method: languages.CompletionItemKind.Method,
+  package: languages.CompletionItemKind.Module,
+  type: languages.CompletionItemKind.Class,
+  variable: languages.CompletionItemKind.Variable,
+};
+
+const toMonacoRange = (range: IDERange) => new Range(
+  range.start.line + 1,
+  range.start.character + 1,
+  range.end.line + 1,
+  range.end.character + 1,
+);
+
+const synchronizeDocument = async (model: editor.ITextModel) => {
+  await updateIDEDocument({
+    uri: model.uri.toString(),
+    source: model.getValue(),
+    version: model.getVersionId(),
+  });
+};
+
+const documentPosition = (
+  model: editor.ITextModel,
+  position: { lineNumber: number; column: number },
+): IDEDocumentPosition => ({
+  uri: model.uri.toString(),
+  version: model.getVersionId(),
+  position: {
+    line: position.lineNumber - 1,
+    character: position.column - 1,
+  },
+});
+
+export const registerGoIDE = () => languages.registerCompletionItemProvider(
+  { language: "go", scheme: "file" },
+  {
+    triggerCharacters: ["."],
+    provideCompletionItems: async (model, position, _context, token) => {
+      if (model.uri.toString() !== GO_SOURCE_URI) {
+        return { suggestions: [] };
+      }
+
+      await synchronizeDocument(model);
+      if (token.isCancellationRequested) return { suggestions: [] };
+
+      const completion = await completeGo(documentPosition(model, position));
+      if (token.isCancellationRequested) return { suggestions: [] };
+
+      return {
+        suggestions: completion.items.map((item) => ({
+          label: item.label,
+          detail: item.detail,
+          insertText: item.insertText,
+          kind: completionKinds[item.kind],
+          range: toMonacoRange(item.replace),
+        })),
+      };
+    },
+  },
+);

--- a/src/viewers/shared/CodeViewer.tsx
+++ b/src/viewers/shared/CodeViewer.tsx
@@ -4,6 +4,7 @@ import { Editor } from "@monaco-editor/react";
 import ScrollType = editor.ScrollType;
 
 export interface CodeViewerProps {
+  readonly path?: string;
   readonly content?: string;
   readonly initialContent?: string;
   readonly line?: number;
@@ -99,6 +100,7 @@ export const CodeViewer = (props: CodeViewerProps) => {
 
   return (
     <Editor
+      path={props.path}
       height={props.height ?? "100%"}
       language="go"
       theme={props.theme === "light" ? "goggle-light" : "goggle-dark"}

--- a/src/wasm/client.ts
+++ b/src/wasm/client.ts
@@ -1,4 +1,12 @@
-import type { WasmParseResult } from "./protocol.ts";
+import type {
+  IDEDocument,
+  IDEDocumentPosition,
+  IDEHover,
+  IDELocation,
+  IDECompletionList,
+  IDESignatureHelp,
+  WasmParseResult,
+} from "./protocol.ts";
 import type {
   WorkerMethod,
   WorkerRequest,
@@ -56,3 +64,22 @@ export const loadGoggleWasm = async () => {
 
 export const parseGoSource = (source: string): Promise<WasmParseResult> =>
   request("analyze", { source });
+
+export const updateIDEDocument = (document: IDEDocument): Promise<null> =>
+  request("ide/update", document);
+
+export const completeGo = (
+  params: IDEDocumentPosition,
+): Promise<IDECompletionList> => request("ide/completion", params);
+
+export const hoverGo = (
+  params: IDEDocumentPosition,
+): Promise<IDEHover | null> => request("ide/hover", params);
+
+export const defineGo = (
+  params: IDEDocumentPosition,
+): Promise<IDELocation | null> => request("ide/definition", params);
+
+export const signatureHelpGo = (
+  params: IDEDocumentPosition,
+): Promise<IDESignatureHelp | null> => request("ide/signatureHelp", params);

--- a/src/wasm/protocol.ts
+++ b/src/wasm/protocol.ts
@@ -84,3 +84,92 @@ export interface AnalysisResult {
 export type WasmParseResult =
   | { body: string; error?: undefined }
   | { body?: undefined; error: string };
+
+export interface IDEDocument {
+  uri: string;
+  source: string;
+  version: number;
+}
+
+export interface IDEPosition {
+  line: number;
+  character: number;
+}
+
+export interface IDERange {
+  start: IDEPosition;
+  end: IDEPosition;
+}
+
+export interface IDEDocumentPosition {
+  uri: string;
+  version: number;
+  position: IDEPosition;
+}
+
+export type IDECompletionKind =
+  | "constant"
+  | "field"
+  | "function"
+  | "keyword"
+  | "method"
+  | "package"
+  | "type"
+  | "variable";
+
+export interface IDECompletionItem {
+  label: string;
+  detail?: string;
+  insertText: string;
+  kind: IDECompletionKind;
+  replace: IDERange;
+}
+
+export interface IDECompletionList {
+  items: IDECompletionItem[];
+}
+
+export interface IDEHover {
+  contents: string;
+  range?: IDERange;
+}
+
+export interface IDELocation {
+  uri: string;
+  range: IDERange;
+}
+
+export interface IDEParameterInformation {
+  label: string;
+  documentation?: string;
+}
+
+export interface IDESignatureInformation {
+  label: string;
+  documentation?: string;
+  parameters: IDEParameterInformation[];
+}
+
+export interface IDESignatureHelp {
+  signatures: IDESignatureInformation[];
+  activeSignature: number;
+  activeParameter: number;
+}
+
+export interface IDERequestMap {
+  update: IDEDocument;
+  completion: IDEDocumentPosition;
+  hover: IDEDocumentPosition;
+  definition: IDEDocumentPosition;
+  signatureHelp: IDEDocumentPosition;
+}
+
+export interface IDEResultMap {
+  update: null;
+  completion: IDECompletionList;
+  hover: IDEHover | null;
+  definition: IDELocation | null;
+  signatureHelp: IDESignatureHelp | null;
+}
+
+export type IDEMethod = keyof IDERequestMap;

--- a/src/wasm/runtime.d.ts
+++ b/src/wasm/runtime.d.ts
@@ -11,6 +11,7 @@ declare global {
   };
 
   var parse: ((source: string) => WasmParseResult) | undefined;
+  var ide: ((request: string) => WasmParseResult) | undefined;
 }
 
 export {};

--- a/src/wasm/worker.ts
+++ b/src/wasm/worker.ts
@@ -2,7 +2,12 @@
 
 import "./generated/wasm_exec.js";
 import goggleWasm from "./generated/goggle.wasm?url";
-import type { WasmParseResult } from "./protocol.ts";
+import type {
+  IDEMethod,
+  IDERequestMap,
+  IDEResultMap,
+  WasmParseResult,
+} from "./protocol.ts";
 import type { WorkerRequest, WorkerResponse } from "./workerProtocol.ts";
 
 const PARSER_TIMEOUT = 30_000;
@@ -61,14 +66,46 @@ const analyze = async (source: string): Promise<WasmParseResult> => {
   return result;
 };
 
+const requestIDE = async <Method extends IDEMethod>(
+  method: Method,
+  params: IDERequestMap[Method],
+): Promise<IDEResultMap[Method]> => {
+  await loadGoggleWasm();
+  const response = globalThis.ide?.(JSON.stringify({ method, params }));
+  if (response === undefined) {
+    throw new Error("Go WebAssembly IDE service is unavailable");
+  }
+  if (response.error !== undefined) {
+    throw new Error(response.error);
+  }
+  return JSON.parse(response.body) as IDEResultMap[Method];
+};
+
+const execute = (request: WorkerRequest): Promise<unknown> => {
+  switch (request.method) {
+    case "initialize":
+      return loadGoggleWasm().then(() => null);
+    case "analyze":
+      return analyze(request.params.source);
+    case "ide/update":
+      return requestIDE("update", request.params);
+    case "ide/completion":
+      return requestIDE("completion", request.params);
+    case "ide/hover":
+      return requestIDE("hover", request.params);
+    case "ide/definition":
+      return requestIDE("definition", request.params);
+    case "ide/signatureHelp":
+      return requestIDE("signatureHelp", request.params);
+  }
+};
+
 self.addEventListener("message", (event: MessageEvent<WorkerRequest>) => {
   const request = event.data;
 
   void (async () => {
     try {
-      const result = request.method === "initialize"
-        ? await loadGoggleWasm().then(() => null)
-        : await analyze(request.params.source);
+      const result = await execute(request);
       const response: WorkerResponse = { id: request.id, result };
       self.postMessage(response);
     } catch (error: unknown) {

--- a/src/wasm/workerProtocol.ts
+++ b/src/wasm/workerProtocol.ts
@@ -1,13 +1,27 @@
-import type { WasmParseResult } from "./protocol.ts";
+import type {
+  IDERequestMap,
+  IDEResultMap,
+  WasmParseResult,
+} from "./protocol.ts";
 
 export interface WorkerRequestMap {
   initialize: undefined;
   analyze: { source: string };
+  "ide/update": IDERequestMap["update"];
+  "ide/completion": IDERequestMap["completion"];
+  "ide/hover": IDERequestMap["hover"];
+  "ide/definition": IDERequestMap["definition"];
+  "ide/signatureHelp": IDERequestMap["signatureHelp"];
 }
 
 export interface WorkerResultMap {
   initialize: null;
   analyze: WasmParseResult;
+  "ide/update": IDEResultMap["update"];
+  "ide/completion": IDEResultMap["completion"];
+  "ide/hover": IDEResultMap["hover"];
+  "ide/definition": IDEResultMap["definition"];
+  "ide/signatureHelp": IDEResultMap["signatureHelp"];
 }
 
 export type WorkerMethod = keyof WorkerRequestMap;

--- a/wasm/cmd/goggle-wasm/main.go
+++ b/wasm/cmd/goggle-wasm/main.go
@@ -8,6 +8,7 @@ import (
 	"syscall/js"
 
 	"github.com/yuxincs/goggle/analyzer"
+	"github.com/yuxincs/goggle/ide"
 )
 
 func main() {
@@ -32,6 +33,50 @@ func main() {
 		}
 
 		result, err := analyzer.Analyze(args[0].String())
+		if err != nil {
+			return js.ValueOf(map[string]interface{}{
+				"error": err.Error(),
+			})
+		}
+		data, err := json.Marshal(result)
+		if err != nil {
+			return js.ValueOf(map[string]interface{}{
+				"error": err.Error(),
+			})
+		}
+		return js.ValueOf(map[string]interface{}{
+			"body": string(data),
+		})
+	}))
+
+	ideService := ide.NewService()
+	js.Global().Set("ide", js.FuncOf(func(this js.Value, args []js.Value) (output any) {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				output = js.ValueOf(map[string]interface{}{
+					"error": fmt.Sprintf("%s", recovered),
+				})
+			}
+		}()
+
+		if len(args) != 1 {
+			return js.ValueOf(map[string]interface{}{
+				"error": fmt.Sprintf("expected 1 argument, got %d", len(args)),
+			})
+		}
+		if args[0].Type() != js.TypeString {
+			return js.ValueOf(map[string]interface{}{
+				"error": fmt.Sprintf("expected a string, got %s", args[0].Type()),
+			})
+		}
+
+		var request ide.Request
+		if err := json.Unmarshal([]byte(args[0].String()), &request); err != nil {
+			return js.ValueOf(map[string]interface{}{
+				"error": fmt.Sprintf("decode IDE request: %s", err),
+			})
+		}
+		result, err := ideService.Handle(request)
 		if err != nil {
 			return js.ValueOf(map[string]interface{}{
 				"error": err.Error(),

--- a/wasm/ide/completion.go
+++ b/wasm/ide/completion.go
@@ -1,0 +1,276 @@
+package ide
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"sort"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const completionMarker = "__goggle_completion__"
+
+var completionKeywords = []string{
+	"break", "case", "chan", "const", "continue", "default", "defer",
+	"else", "fallthrough", "for", "func", "go", "goto", "if", "import",
+	"interface", "map", "package", "range", "return", "select", "struct",
+	"switch", "type", "var",
+}
+
+func (service *Service) Complete(params DocumentPosition) (*CompletionList, error) {
+	current, err := service.snapshotFor(params)
+	if err != nil {
+		return nil, err
+	}
+	offset, err := offsetForPosition(current.document.Source, params.Position)
+	if err != nil {
+		return nil, err
+	}
+
+	start := identifierStart(current.document.Source, offset)
+	prefix := current.document.Source[start:offset]
+	modified := current.document.Source[:offset] + completionMarker + current.document.Source[offset:]
+	completionSnapshot, err := buildSnapshot(Document{
+		URI:     current.document.URI,
+		Source:  modified,
+		Version: current.document.Version,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("prepare completion: %w", err)
+	}
+	cursor := completionSnapshot.tokenFile.Pos(offset)
+	replace, err := rangeForOffsets(current.document.Source, start, offset)
+	if err != nil {
+		return nil, err
+	}
+
+	candidates := make(map[string]CompletionItem)
+	if selector := completionSelector(completionSnapshot.file); selector != nil {
+		service.addSelectorCandidates(candidates, completionSnapshot, selector, prefix, replace)
+	} else {
+		addScopeCandidates(candidates, completionSnapshot, cursor, prefix, replace)
+		addKeywordCandidates(candidates, prefix, replace)
+	}
+
+	items := make([]CompletionItem, 0, len(candidates))
+	for _, item := range candidates {
+		items = append(items, item)
+	}
+	sort.Slice(items, func(left, right int) bool {
+		return items[left].Label < items[right].Label
+	})
+	return &CompletionList{Items: items}, nil
+}
+
+func completionSelector(file *ast.File) *ast.SelectorExpr {
+	var result *ast.SelectorExpr
+	ast.Inspect(file, func(node ast.Node) bool {
+		selector, ok := node.(*ast.SelectorExpr)
+		if ok && strings.HasSuffix(selector.Sel.Name, completionMarker) {
+			result = selector
+			return false
+		}
+		return result == nil
+	})
+	return result
+}
+
+func (service *Service) addSelectorCandidates(
+	candidates map[string]CompletionItem,
+	snapshot *snapshot,
+	selector *ast.SelectorExpr,
+	prefix string,
+	replace Range,
+) {
+	if identifier, ok := selector.X.(*ast.Ident); ok {
+		if packageName, ok := snapshot.info.Uses[identifier].(*types.PkgName); ok {
+			addObjectCandidates(candidates, packageName.Imported().Scope(), prefix, replace, token.NoPos)
+			return
+		}
+	}
+
+	typeOfReceiver := snapshot.info.TypeOf(selector.X)
+	if typeOfReceiver == nil {
+		return
+	}
+	addMethodCandidates(candidates, typeOfReceiver, prefix, replace)
+	addFieldCandidates(candidates, typeOfReceiver, prefix, replace)
+}
+
+func addScopeCandidates(
+	candidates map[string]CompletionItem,
+	snapshot *snapshot,
+	position token.Pos,
+	prefix string,
+	replace Range,
+) {
+	var innermost *types.Scope
+	for _, scope := range snapshot.info.Scopes {
+		if !scope.Contains(position) {
+			continue
+		}
+		if innermost == nil || scope.Pos() >= innermost.Pos() && scope.End() <= innermost.End() {
+			innermost = scope
+		}
+	}
+	if innermost == nil {
+		innermost = snapshot.pkg.Scope()
+	}
+
+	for scope := innermost; scope != nil; scope = scope.Parent() {
+		addObjectCandidates(candidates, scope, prefix, replace, position)
+	}
+}
+
+func addObjectCandidates(
+	candidates map[string]CompletionItem,
+	scope *types.Scope,
+	prefix string,
+	replace Range,
+	position token.Pos,
+) {
+	for _, name := range scope.Names() {
+		object := scope.Lookup(name)
+		if object == nil || !matchesPrefix(name, prefix) {
+			continue
+		}
+		if position.IsValid() && object.Pos().IsValid() && object.Pos() > position && scope.Parent() != types.Universe {
+			continue
+		}
+		addCandidate(candidates, objectCandidate(object, replace))
+	}
+}
+
+func addMethodCandidates(
+	candidates map[string]CompletionItem,
+	receiver types.Type,
+	prefix string,
+	replace Range,
+) {
+	sets := []*types.MethodSet{types.NewMethodSet(receiver)}
+	if _, isPointer := receiver.(*types.Pointer); !isPointer {
+		sets = append(sets, types.NewMethodSet(types.NewPointer(receiver)))
+	}
+	for _, set := range sets {
+		for index := 0; index < set.Len(); index++ {
+			method := set.At(index).Obj()
+			if !matchesPrefix(method.Name(), prefix) {
+				continue
+			}
+			item := objectCandidate(method, replace)
+			item.Kind = CompletionMethod
+			addCandidate(candidates, item)
+		}
+	}
+}
+
+func addFieldCandidates(
+	candidates map[string]CompletionItem,
+	receiver types.Type,
+	prefix string,
+	replace Range,
+) {
+	if pointer, ok := receiver.(*types.Pointer); ok {
+		receiver = pointer.Elem()
+	}
+	underlying := receiver.Underlying()
+	structure, ok := underlying.(*types.Struct)
+	if !ok {
+		return
+	}
+	for index := 0; index < structure.NumFields(); index++ {
+		field := structure.Field(index)
+		if !matchesPrefix(field.Name(), prefix) {
+			continue
+		}
+		item := objectCandidate(field, replace)
+		item.Kind = CompletionField
+		addCandidate(candidates, item)
+	}
+}
+
+func addKeywordCandidates(
+	candidates map[string]CompletionItem,
+	prefix string,
+	replace Range,
+) {
+	for _, keyword := range completionKeywords {
+		if matchesPrefix(keyword, prefix) {
+			addCandidate(candidates, CompletionItem{
+				Label:      keyword,
+				InsertText: keyword,
+				Kind:       CompletionKeyword,
+				Replace:    replace,
+			})
+		}
+	}
+}
+
+func objectCandidate(object types.Object, replace Range) CompletionItem {
+	return CompletionItem{
+		Label:      object.Name(),
+		Detail:     types.ObjectString(object, nil),
+		InsertText: object.Name(),
+		Kind:       completionKindForObject(object),
+		Replace:    replace,
+	}
+}
+
+func completionKindForObject(object types.Object) CompletionKind {
+	switch object := object.(type) {
+	case *types.Const:
+		return CompletionConstant
+	case *types.Func:
+		if signature, ok := object.Type().(*types.Signature); ok && signature.Recv() != nil {
+			return CompletionMethod
+		}
+		return CompletionFunction
+	case *types.PkgName:
+		return CompletionPackage
+	case *types.TypeName:
+		return CompletionType
+	case *types.Var:
+		if object.IsField() {
+			return CompletionField
+		}
+		return CompletionVariable
+	default:
+		return CompletionVariable
+	}
+}
+
+func addCandidate(candidates map[string]CompletionItem, item CompletionItem) {
+	if _, exists := candidates[item.Label]; !exists {
+		candidates[item.Label] = item
+	}
+}
+
+func matchesPrefix(name, prefix string) bool {
+	return strings.HasPrefix(strings.ToLower(name), strings.ToLower(prefix))
+}
+
+func identifierStart(source string, offset int) int {
+	for offset > 0 {
+		character, size := utf8.DecodeLastRuneInString(source[:offset])
+		if character != '_' && !unicode.IsLetter(character) && !unicode.IsDigit(character) {
+			break
+		}
+		offset -= size
+	}
+	return offset
+}
+
+func rangeForOffsets(source string, start, end int) (Range, error) {
+	startPosition, err := positionForOffset(source, start)
+	if err != nil {
+		return Range{}, err
+	}
+	endPosition, err := positionForOffset(source, end)
+	if err != nil {
+		return Range{}, err
+	}
+	return Range{Start: startPosition, End: endPosition}, nil
+}

--- a/wasm/ide/completion_test.go
+++ b/wasm/ide/completion_test.go
@@ -1,0 +1,71 @@
+package ide_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yuxincs/goggle/ide"
+)
+
+func TestCompletion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		source   string
+		position ide.Position
+		want     string
+	}{
+		{
+			name: "local variable",
+			source: `package main
+
+func main() {
+	value := 1
+	val
+}
+`,
+			position: ide.Position{Line: 4, Character: 4},
+			want:     "value",
+		},
+		{
+			name: "standard library selector",
+			source: `package main
+
+import "fmt"
+
+func main() {
+	fmt.Pr
+}
+`,
+			position: ide.Position{Line: 5, Character: 7},
+			want:     "Println",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			service := ide.NewService()
+			document := ide.Document{
+				URI:     "main.go",
+				Source:  test.source,
+				Version: 1,
+			}
+			require.NoError(t, service.Update(document))
+			completion, err := service.Complete(ide.DocumentPosition{
+				URI:      document.URI,
+				Version:  document.Version,
+				Position: test.position,
+			})
+			require.NoError(t, err)
+
+			labels := make([]string, 0, len(completion.Items))
+			for _, item := range completion.Items {
+				labels = append(labels, item.Label)
+			}
+			require.Contains(t, labels, test.want)
+		})
+	}
+}

--- a/wasm/ide/position.go
+++ b/wasm/ide/position.go
@@ -1,0 +1,73 @@
+package ide
+
+import (
+	"fmt"
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+func offsetForPosition(source string, position Position) (int, error) {
+	if position.Line < 0 || position.Character < 0 {
+		return 0, fmt.Errorf("invalid position %d:%d", position.Line, position.Character)
+	}
+
+	line := 0
+	lineStart := 0
+	for index, character := range source {
+		if line == position.Line {
+			lineStart = index
+			break
+		}
+		if character == '\n' {
+			line++
+			lineStart = index + 1
+		}
+	}
+	if position.Line > line {
+		return 0, fmt.Errorf("line %d is outside the document", position.Line)
+	}
+
+	units := 0
+	for offset, character := range source[lineStart:] {
+		if character == '\n' {
+			break
+		}
+		if units == position.Character {
+			return lineStart + offset, nil
+		}
+		units += utf16.RuneLen(character)
+		if units > position.Character {
+			return 0, fmt.Errorf("character %d splits a UTF-16 surrogate pair", position.Character)
+		}
+	}
+	if units == position.Character {
+		return lineStart + lenLine(source[lineStart:]), nil
+	}
+	return 0, fmt.Errorf("character %d is outside line %d", position.Character, position.Line)
+}
+
+func positionForOffset(source string, offset int) (Position, error) {
+	if offset < 0 || offset > len(source) || !utf8.ValidString(source[:offset]) {
+		return Position{}, fmt.Errorf("invalid source offset %d", offset)
+	}
+
+	position := Position{}
+	for _, character := range source[:offset] {
+		if character == '\n' {
+			position.Line++
+			position.Character = 0
+			continue
+		}
+		position.Character += utf16.RuneLen(character)
+	}
+	return position, nil
+}
+
+func lenLine(source string) int {
+	for index, character := range source {
+		if character == '\n' {
+			return index
+		}
+	}
+	return len(source)
+}

--- a/wasm/ide/position_test.go
+++ b/wasm/ide/position_test.go
@@ -1,0 +1,32 @@
+package ide
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPositionRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	const source = "α😀z\nnext"
+	tests := []struct {
+		position Position
+		offset   int
+	}{
+		{position: Position{Line: 0, Character: 0}, offset: 0},
+		{position: Position{Line: 0, Character: 1}, offset: len("α")},
+		{position: Position{Line: 0, Character: 3}, offset: len("α😀")},
+		{position: Position{Line: 1, Character: 2}, offset: len("α😀z\nne")},
+	}
+
+	for _, test := range tests {
+		offset, err := offsetForPosition(source, test.position)
+		require.NoError(t, err)
+		require.Equal(t, test.offset, offset)
+
+		position, err := positionForOffset(source, offset)
+		require.NoError(t, err)
+		require.Equal(t, test.position, position)
+	}
+}

--- a/wasm/ide/service.go
+++ b/wasm/ide/service.go
@@ -1,0 +1,154 @@
+package ide
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+
+	"github.com/yuxincs/goggle/internal/stdlib"
+)
+
+var ErrNotImplemented = errors.New("IDE capability is not implemented")
+
+type Service struct {
+	snapshot *snapshot
+}
+
+type snapshot struct {
+	document  Document
+	fset      *token.FileSet
+	file      *ast.File
+	tokenFile *token.File
+	pkg       *types.Package
+	info      *types.Info
+}
+
+func NewService() *Service {
+	return &Service{}
+}
+
+func (service *Service) Handle(request Request) (any, error) {
+	switch request.Method {
+	case MethodUpdate:
+		var document Document
+		if err := json.Unmarshal(request.Params, &document); err != nil {
+			return nil, fmt.Errorf("decode document update: %w", err)
+		}
+		return nil, service.Update(document)
+	case MethodCompletion:
+		var params DocumentPosition
+		if err := json.Unmarshal(request.Params, &params); err != nil {
+			return nil, fmt.Errorf("decode completion request: %w", err)
+		}
+		return service.Complete(params)
+	case MethodHover:
+		var params DocumentPosition
+		if err := json.Unmarshal(request.Params, &params); err != nil {
+			return nil, fmt.Errorf("decode hover request: %w", err)
+		}
+		return service.Hover(params)
+	case MethodDefinition:
+		var params DocumentPosition
+		if err := json.Unmarshal(request.Params, &params); err != nil {
+			return nil, fmt.Errorf("decode definition request: %w", err)
+		}
+		return service.Definition(params)
+	case MethodSignatureHelp:
+		var params DocumentPosition
+		if err := json.Unmarshal(request.Params, &params); err != nil {
+			return nil, fmt.Errorf("decode signature help request: %w", err)
+		}
+		return service.SignatureHelp(params)
+	default:
+		return nil, fmt.Errorf("unknown IDE method %q", request.Method)
+	}
+}
+
+func (service *Service) Update(document Document) error {
+	if service.snapshot != nil && service.snapshot.document == document {
+		return nil
+	}
+
+	snapshot, err := buildSnapshot(document)
+	if err != nil {
+		return err
+	}
+	service.snapshot = snapshot
+	return nil
+}
+
+func (service *Service) Hover(DocumentPosition) (*Hover, error) {
+	return nil, fmt.Errorf("hover: %w", ErrNotImplemented)
+}
+
+func (service *Service) Definition(DocumentPosition) (*Location, error) {
+	return nil, fmt.Errorf("definition: %w", ErrNotImplemented)
+}
+
+func (service *Service) SignatureHelp(DocumentPosition) (*SignatureHelp, error) {
+	return nil, fmt.Errorf("signature help: %w", ErrNotImplemented)
+}
+
+func (service *Service) snapshotFor(params DocumentPosition) (*snapshot, error) {
+	if service.snapshot == nil {
+		return nil, errors.New("IDE document has not been initialized")
+	}
+	if service.snapshot.document.URI != params.URI {
+		return nil, fmt.Errorf("IDE document %q is not open", params.URI)
+	}
+	if service.snapshot.document.Version != params.Version {
+		return nil, fmt.Errorf(
+			"stale IDE document version: got %d, want %d",
+			params.Version,
+			service.snapshot.document.Version,
+		)
+	}
+	return service.snapshot, nil
+}
+
+func buildSnapshot(document Document) (*snapshot, error) {
+	fset := token.NewFileSet()
+	file, parseErr := parser.ParseFile(
+		fset,
+		document.URI,
+		document.Source,
+		parser.AllErrors|parser.ParseComments,
+	)
+	if file == nil {
+		return nil, fmt.Errorf("parse IDE document: %w", parseErr)
+	}
+
+	importer, err := stdlib.NewImporter(fset)
+	if err != nil {
+		return nil, err
+	}
+	info := &types.Info{
+		Types:      make(map[ast.Expr]types.TypeAndValue),
+		Defs:       make(map[*ast.Ident]types.Object),
+		Uses:       make(map[*ast.Ident]types.Object),
+		Implicits:  make(map[ast.Node]types.Object),
+		Selections: make(map[*ast.SelectorExpr]*types.Selection),
+		Scopes:     make(map[ast.Node]*types.Scope),
+	}
+	config := &types.Config{
+		Importer: importer,
+		Error:    func(error) {},
+	}
+	pkg, _ := config.Check(file.Name.Name, fset, []*ast.File{file}, info)
+	if pkg == nil {
+		pkg = types.NewPackage(file.Name.Name, file.Name.Name)
+	}
+
+	return &snapshot{
+		document:  document,
+		fset:      fset,
+		file:      file,
+		tokenFile: fset.File(file.Pos()),
+		pkg:       pkg,
+		info:      info,
+	}, nil
+}

--- a/wasm/ide/types.go
+++ b/wasm/ide/types.go
@@ -1,0 +1,92 @@
+package ide
+
+import "encoding/json"
+
+type Method string
+
+const (
+	MethodUpdate        Method = "update"
+	MethodCompletion    Method = "completion"
+	MethodHover         Method = "hover"
+	MethodDefinition    Method = "definition"
+	MethodSignatureHelp Method = "signatureHelp"
+)
+
+type Request struct {
+	Method Method          `json:"method"`
+	Params json.RawMessage `json:"params"`
+}
+
+type Document struct {
+	URI     string `json:"uri"`
+	Source  string `json:"source"`
+	Version int    `json:"version"`
+}
+
+type Position struct {
+	Line      int `json:"line"`
+	Character int `json:"character"`
+}
+
+type Range struct {
+	Start Position `json:"start"`
+	End   Position `json:"end"`
+}
+
+type DocumentPosition struct {
+	URI      string   `json:"uri"`
+	Version  int      `json:"version"`
+	Position Position `json:"position"`
+}
+
+type CompletionKind string
+
+const (
+	CompletionConstant CompletionKind = "constant"
+	CompletionField    CompletionKind = "field"
+	CompletionFunction CompletionKind = "function"
+	CompletionKeyword  CompletionKind = "keyword"
+	CompletionMethod   CompletionKind = "method"
+	CompletionPackage  CompletionKind = "package"
+	CompletionType     CompletionKind = "type"
+	CompletionVariable CompletionKind = "variable"
+)
+
+type CompletionItem struct {
+	Label      string         `json:"label"`
+	Detail     string         `json:"detail,omitempty"`
+	InsertText string         `json:"insertText"`
+	Kind       CompletionKind `json:"kind"`
+	Replace    Range          `json:"replace"`
+}
+
+type CompletionList struct {
+	Items []CompletionItem `json:"items"`
+}
+
+type Hover struct {
+	Contents string `json:"contents"`
+	Range    *Range `json:"range,omitempty"`
+}
+
+type Location struct {
+	URI   string `json:"uri"`
+	Range Range  `json:"range"`
+}
+
+type ParameterInformation struct {
+	Label         string `json:"label"`
+	Documentation string `json:"documentation,omitempty"`
+}
+
+type SignatureInformation struct {
+	Label         string                 `json:"label"`
+	Documentation string                 `json:"documentation,omitempty"`
+	Parameters    []ParameterInformation `json:"parameters"`
+}
+
+type SignatureHelp struct {
+	Signatures      []SignatureInformation `json:"signatures"`
+	ActiveSignature int                    `json:"activeSignature"`
+	ActiveParameter int                    `json:"activeParameter"`
+}


### PR DESCRIPTION
Introduces the Go ide service and typed protocols for document updates, completion, hover, definition, and signature help. Implements UTF-16-safe local, selector, and standard-library completion in Monaco; later capabilities remain isolated behind their protocol methods.\n\nChecks:\n- go test ./...\n- GOOS=js GOARCH=wasm go test -exec=... ./...\n- go vet ./...\n- npm run lint\n- npm run build