### PR TITLE
Add Go hover support

### DIFF
--- a/src/editor/ide.ts
+++ b/src/editor/ide.ts
@@ -4,7 +4,7 @@ import type {
   IDEDocumentPosition,
   IDERange,
 } from "../wasm/protocol.ts";
-import { completeGo, updateIDEDocument } from "../wasm/client.ts";
+import { completeGo, hoverGo, updateIDEDocument } from "../wasm/client.ts";
 
 export const GO_SOURCE_URI = "file:///main.go";
 
@@ -49,30 +49,54 @@ const documentPosition = (
   },
 });
 
-export const registerGoIDE = () => languages.registerCompletionItemProvider(
-  { language: "go", scheme: "file" },
-  {
-    triggerCharacters: ["."],
-    provideCompletionItems: async (model, position, _context, token) => {
-      if (model.uri.toString() !== GO_SOURCE_URI) {
-        return { suggestions: [] };
-      }
+export const registerGoIDE = () => {
+  const selector = { language: "go", scheme: "file" };
+  const providers = [
+    languages.registerCompletionItemProvider(selector, {
+      triggerCharacters: ["."],
+      provideCompletionItems: async (model, position, _context, token) => {
+        if (model.uri.toString() !== GO_SOURCE_URI) {
+          return { suggestions: [] };
+        }
 
-      await synchronizeDocument(model);
-      if (token.isCancellationRequested) return { suggestions: [] };
+        await synchronizeDocument(model);
+        if (token.isCancellationRequested) return { suggestions: [] };
 
-      const completion = await completeGo(documentPosition(model, position));
-      if (token.isCancellationRequested) return { suggestions: [] };
+        const completion = await completeGo(documentPosition(model, position));
+        if (token.isCancellationRequested) return { suggestions: [] };
 
-      return {
-        suggestions: completion.items.map((item) => ({
-          label: item.label,
-          detail: item.detail,
-          insertText: item.insertText,
-          kind: completionKinds[item.kind],
-          range: toMonacoRange(item.replace),
-        })),
-      };
-    },
-  },
-);
+        return {
+          suggestions: completion.items.map((item) => ({
+            label: item.label,
+            detail: item.detail,
+            insertText: item.insertText,
+            kind: completionKinds[item.kind],
+            range: toMonacoRange(item.replace),
+          })),
+        };
+      },
+    }),
+    languages.registerHoverProvider(selector, {
+      provideHover: async (model, position, token) => {
+        if (model.uri.toString() !== GO_SOURCE_URI) return null;
+
+        await synchronizeDocument(model);
+        if (token.isCancellationRequested) return null;
+
+        const hover = await hoverGo(documentPosition(model, position));
+        if (hover === null || token.isCancellationRequested) return null;
+
+        return {
+          contents: [{ value: `\`\`\`go\n${hover.contents}\n\`\`\`` }],
+          range: hover.range === undefined
+            ? undefined
+            : toMonacoRange(hover.range),
+        };
+      },
+    }),
+  ];
+
+  return {
+    dispose: () => providers.forEach((provider) => provider.dispose()),
+  };
+};

--- a/wasm/ide/hover.go
+++ b/wasm/ide/hover.go
@@ -1,0 +1,23 @@
+package ide
+
+import "go/types"
+
+func (service *Service) Hover(params DocumentPosition) (*Hover, error) {
+	snapshot, err := service.snapshotFor(params)
+	if err != nil {
+		return nil, err
+	}
+	resolved, err := objectAtPosition(snapshot, params.Position)
+	if err != nil || resolved == nil {
+		return nil, err
+	}
+
+	hoverRange, err := rangeForNode(snapshot, resolved.identifier)
+	if err != nil {
+		return nil, err
+	}
+	return &Hover{
+		Contents: types.ObjectString(resolved.object, types.RelativeTo(snapshot.pkg)),
+		Range:    &hoverRange,
+	}, nil
+}

--- a/wasm/ide/hover_test.go
+++ b/wasm/ide/hover_test.go
@@ -1,0 +1,37 @@
+package ide_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yuxincs/goggle/ide"
+)
+
+func TestHover(t *testing.T) {
+	t.Parallel()
+
+	const source = `package main
+
+func add(left, right int) int { return left + right }
+
+func main() {
+	_ = add(1, 2)
+}
+`
+	service := ide.NewService()
+	document := ide.Document{URI: "main.go", Source: source, Version: 1}
+	require.NoError(t, service.Update(document))
+
+	hover, err := service.Hover(ide.DocumentPosition{
+		URI:      document.URI,
+		Version:  document.Version,
+		Position: ide.Position{Line: 5, Character: 5},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, hover)
+	require.Equal(t, "func add(left int, right int) int", hover.Contents)
+	require.Equal(t, ide.Range{
+		Start: ide.Position{Line: 5, Character: 5},
+		End:   ide.Position{Line: 5, Character: 8},
+	}, *hover.Range)
+}

--- a/wasm/ide/object.go
+++ b/wasm/ide/object.go
@@ -1,0 +1,73 @@
+package ide
+
+import (
+	"errors"
+	"go/ast"
+	"go/token"
+	"go/types"
+)
+
+type resolvedObject struct {
+	identifier *ast.Ident
+	object     types.Object
+	selection  *types.Selection
+}
+
+func objectAtPosition(snapshot *snapshot, position Position) (*resolvedObject, error) {
+	offset, err := offsetForPosition(snapshot.document.Source, position)
+	if err != nil {
+		return nil, err
+	}
+	tokenPosition := snapshot.tokenFile.Pos(offset)
+
+	var identifier *ast.Ident
+	ast.Inspect(snapshot.file, func(node ast.Node) bool {
+		current, ok := node.(*ast.Ident)
+		if !ok || tokenPosition < current.Pos() || tokenPosition > current.End() {
+			return true
+		}
+		identifier = current
+		return false
+	})
+	if identifier == nil {
+		return nil, nil
+	}
+
+	object := snapshot.info.ObjectOf(identifier)
+	if object == nil {
+		return nil, nil
+	}
+	return &resolvedObject{
+		identifier: identifier,
+		object:     object,
+		selection:  selectionForIdentifier(snapshot.info, identifier),
+	}, nil
+}
+
+func selectionForIdentifier(info *types.Info, identifier *ast.Ident) *types.Selection {
+	for expression, selection := range info.Selections {
+		if expression.Sel == identifier {
+			return selection
+		}
+	}
+	return nil
+}
+
+func rangeForNode(snapshot *snapshot, node ast.Node) (Range, error) {
+	if snapshot.tokenFile == nil {
+		return Range{}, errors.New("IDE document has no token file")
+	}
+	return rangeForOffsets(
+		snapshot.document.Source,
+		snapshot.tokenFile.Offset(node.Pos()),
+		snapshot.tokenFile.Offset(node.End()),
+	)
+}
+
+func objectPosition(snapshot *snapshot, object types.Object) (token.Position, bool) {
+	if !object.Pos().IsValid() {
+		return token.Position{}, false
+	}
+	position := snapshot.fset.PositionFor(object.Pos(), false)
+	return position, position.IsValid()
+}

--- a/wasm/ide/service.go
+++ b/wasm/ide/service.go
@@ -81,10 +81,6 @@ func (service *Service) Update(document Document) error {
 	return nil
 }
 
-func (service *Service) Hover(DocumentPosition) (*Hover, error) {
-	return nil, fmt.Errorf("hover: %w", ErrNotImplemented)
-}
-
 func (service *Service) Definition(DocumentPosition) (*Location, error) {
 	return nil, fmt.Errorf("definition: %w", ErrNotImplemented)
 }


### PR DESCRIPTION
Implements type-aware hover information for identifiers and selectors using the shared IDE snapshot, then registers Monaco’s hover provider.\n\nChecks:\n- go test ./ide\n- npm run lint\n- npm run build