### PR TITLE
Add Go definition support

### DIFF
--- a/src/editor/ide.ts
+++ b/src/editor/ide.ts
@@ -1,10 +1,15 @@
-import { languages, Range, type editor } from "monaco-editor";
+import { languages, Range, Uri, type editor } from "monaco-editor";
 import type {
   IDECompletionKind,
   IDEDocumentPosition,
   IDERange,
 } from "../wasm/protocol.ts";
-import { completeGo, hoverGo, updateIDEDocument } from "../wasm/client.ts";
+import {
+  completeGo,
+  defineGo,
+  hoverGo,
+  updateIDEDocument,
+} from "../wasm/client.ts";
 
 export const GO_SOURCE_URI = "file:///main.go";
 
@@ -91,6 +96,22 @@ export const registerGoIDE = () => {
           range: hover.range === undefined
             ? undefined
             : toMonacoRange(hover.range),
+        };
+      },
+    }),
+    languages.registerDefinitionProvider(selector, {
+      provideDefinition: async (model, position, token) => {
+        if (model.uri.toString() !== GO_SOURCE_URI) return null;
+
+        await synchronizeDocument(model);
+        if (token.isCancellationRequested) return null;
+
+        const definition = await defineGo(documentPosition(model, position));
+        if (definition === null || token.isCancellationRequested) return null;
+
+        return {
+          uri: Uri.parse(definition.uri),
+          range: toMonacoRange(definition.range),
         };
       },
     }),

--- a/wasm/ide/definition.go
+++ b/wasm/ide/definition.go
@@ -1,0 +1,31 @@
+package ide
+
+func (service *Service) Definition(params DocumentPosition) (*Location, error) {
+	snapshot, err := service.snapshotFor(params)
+	if err != nil {
+		return nil, err
+	}
+	resolved, err := objectAtPosition(snapshot, params.Position)
+	if err != nil || resolved == nil {
+		return nil, err
+	}
+
+	definitionPosition, ok := objectPosition(snapshot, resolved.object)
+	if !ok || definitionPosition.Filename != snapshot.document.URI {
+		return nil, nil
+	}
+	for identifier, object := range snapshot.info.Defs {
+		if object != resolved.object {
+			continue
+		}
+		definitionRange, err := rangeForNode(snapshot, identifier)
+		if err != nil {
+			return nil, err
+		}
+		return &Location{
+			URI:   snapshot.document.URI,
+			Range: definitionRange,
+		}, nil
+	}
+	return nil, nil
+}

--- a/wasm/ide/definition_test.go
+++ b/wasm/ide/definition_test.go
@@ -1,0 +1,38 @@
+package ide_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yuxincs/goggle/ide"
+)
+
+func TestDefinition(t *testing.T) {
+	t.Parallel()
+
+	const source = `package main
+
+func add(left, right int) int { return left + right }
+
+func main() {
+	_ = add(1, 2)
+}
+`
+	service := ide.NewService()
+	document := ide.Document{URI: "main.go", Source: source, Version: 1}
+	require.NoError(t, service.Update(document))
+
+	definition, err := service.Definition(ide.DocumentPosition{
+		URI:      document.URI,
+		Version:  document.Version,
+		Position: ide.Position{Line: 5, Character: 5},
+	})
+	require.NoError(t, err)
+	require.Equal(t, &ide.Location{
+		URI: document.URI,
+		Range: ide.Range{
+			Start: ide.Position{Line: 2, Character: 5},
+			End:   ide.Position{Line: 2, Character: 8},
+		},
+	}, definition)
+}

--- a/wasm/ide/service.go
+++ b/wasm/ide/service.go
@@ -81,10 +81,6 @@ func (service *Service) Update(document Document) error {
 	return nil
 }
 
-func (service *Service) Definition(DocumentPosition) (*Location, error) {
-	return nil, fmt.Errorf("definition: %w", ErrNotImplemented)
-}
-
 func (service *Service) SignatureHelp(DocumentPosition) (*SignatureHelp, error) {
 	return nil, fmt.Errorf("signature help: %w", ErrNotImplemented)
 }


### PR DESCRIPTION
Implements go-to-definition for symbols declared in the active document and connects the result to Monaco’s definition provider.\n\nChecks:\n- go test ./ide\n- npm run lint\n- npm run build