### PR TITLE
Add Go signature help

### DIFF
--- a/src/editor/ide.ts
+++ b/src/editor/ide.ts
@@ -8,6 +8,7 @@ import {
   completeGo,
   defineGo,
   hoverGo,
+  signatureHelpGo,
   updateIDEDocument,
 } from "../wasm/client.ts";
 
@@ -112,6 +113,35 @@ export const registerGoIDE = () => {
         return {
           uri: Uri.parse(definition.uri),
           range: toMonacoRange(definition.range),
+        };
+      },
+    }),
+    languages.registerSignatureHelpProvider(selector, {
+      signatureHelpTriggerCharacters: ["(", ","],
+      signatureHelpRetriggerCharacters: [","],
+      provideSignatureHelp: async (model, position, token) => {
+        if (model.uri.toString() !== GO_SOURCE_URI) return null;
+
+        await synchronizeDocument(model);
+        if (token.isCancellationRequested) return null;
+
+        const help = await signatureHelpGo(documentPosition(model, position));
+        if (help === null || token.isCancellationRequested) return null;
+
+        return {
+          value: {
+            signatures: help.signatures.map((signature) => ({
+              label: signature.label,
+              documentation: signature.documentation,
+              parameters: signature.parameters.map((parameter) => ({
+                label: parameter.label,
+                documentation: parameter.documentation,
+              })),
+            })),
+            activeSignature: help.activeSignature,
+            activeParameter: help.activeParameter,
+          },
+          dispose: () => {},
         };
       },
     }),

--- a/wasm/ide/service.go
+++ b/wasm/ide/service.go
@@ -12,8 +12,6 @@ import (
 	"github.com/yuxincs/goggle/internal/stdlib"
 )
 
-var ErrNotImplemented = errors.New("IDE capability is not implemented")
-
 type Service struct {
 	snapshot *snapshot
 }
@@ -79,10 +77,6 @@ func (service *Service) Update(document Document) error {
 	}
 	service.snapshot = snapshot
 	return nil
-}
-
-func (service *Service) SignatureHelp(DocumentPosition) (*SignatureHelp, error) {
-	return nil, fmt.Errorf("signature help: %w", ErrNotImplemented)
 }
 
 func (service *Service) snapshotFor(params DocumentPosition) (*snapshot, error) {

--- a/wasm/ide/signature.go
+++ b/wasm/ide/signature.go
@@ -1,0 +1,101 @@
+package ide
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strings"
+)
+
+func (service *Service) SignatureHelp(params DocumentPosition) (*SignatureHelp, error) {
+	snapshot, err := service.snapshotFor(params)
+	if err != nil {
+		return nil, err
+	}
+	offset, err := offsetForPosition(snapshot.document.Source, params.Position)
+	if err != nil {
+		return nil, err
+	}
+	position := snapshot.tokenFile.Pos(offset)
+	call := callAtPosition(snapshot.file, position)
+	if call == nil {
+		return nil, nil
+	}
+
+	signature, ok := snapshot.info.TypeOf(call.Fun).(*types.Signature)
+	if !ok {
+		return nil, nil
+	}
+	activeParameter := 0
+	for _, argument := range call.Args {
+		if argument.End() < position {
+			activeParameter++
+		}
+	}
+	if count := signature.Params().Len(); count > 0 && activeParameter >= count {
+		activeParameter = count - 1
+	}
+
+	return &SignatureHelp{
+		Signatures:      []SignatureInformation{signatureInformation(snapshot, call, signature)},
+		ActiveSignature: 0,
+		ActiveParameter: activeParameter,
+	}, nil
+}
+
+func callAtPosition(file *ast.File, position token.Pos) *ast.CallExpr {
+	var result *ast.CallExpr
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || position < call.Lparen || position > call.End() {
+			return true
+		}
+		result = call
+		return true
+	})
+	return result
+}
+
+func signatureInformation(
+	snapshot *snapshot,
+	call *ast.CallExpr,
+	signature *types.Signature,
+) SignatureInformation {
+	name := "func"
+	switch function := call.Fun.(type) {
+	case *ast.Ident:
+		name = function.Name
+	case *ast.SelectorExpr:
+		name = function.Sel.Name
+	}
+	label := strings.TrimPrefix(
+		types.TypeString(signature, types.RelativeTo(snapshot.pkg)),
+		"func",
+	)
+
+	parameters := make([]ParameterInformation, 0, signature.Params().Len())
+	for index := 0; index < signature.Params().Len(); index++ {
+		parameter := signature.Params().At(index)
+		parameterType := parameter.Type()
+		variadic := signature.Variadic() && index == signature.Params().Len()-1
+		if variadic {
+			if slice, ok := parameterType.(*types.Slice); ok {
+				parameterType = slice.Elem()
+			}
+		}
+		typeLabel := types.TypeString(parameterType, types.RelativeTo(snapshot.pkg))
+		if variadic {
+			typeLabel = "..." + typeLabel
+		}
+		parameterLabel := typeLabel
+		if parameter.Name() != "" {
+			parameterLabel = parameter.Name() + " " + typeLabel
+		}
+		parameters = append(parameters, ParameterInformation{Label: parameterLabel})
+	}
+
+	return SignatureInformation{
+		Label:      name + label,
+		Parameters: parameters,
+	}
+}

--- a/wasm/ide/signature_test.go
+++ b/wasm/ide/signature_test.go
@@ -1,0 +1,44 @@
+package ide_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yuxincs/goggle/ide"
+)
+
+func TestSignatureHelp(t *testing.T) {
+	t.Parallel()
+
+	const source = `package main
+
+func add(left, right int) int { return left + right }
+
+func main() {
+	_ = add(1, 2)
+}
+`
+	service := ide.NewService()
+	document := ide.Document{URI: "main.go", Source: source, Version: 1}
+	require.NoError(t, service.Update(document))
+
+	help, err := service.SignatureHelp(ide.DocumentPosition{
+		URI:      document.URI,
+		Version:  document.Version,
+		Position: ide.Position{Line: 5, Character: 12},
+	})
+	require.NoError(t, err)
+	require.Equal(t, &ide.SignatureHelp{
+		Signatures: []ide.SignatureInformation{
+			{
+				Label: "add(left int, right int) int",
+				Parameters: []ide.ParameterInformation{
+					{Label: "left int"},
+					{Label: "right int"},
+				},
+			},
+		},
+		ActiveSignature: 0,
+		ActiveParameter: 1,
+	}, help)
+}


### PR DESCRIPTION
Implements signature help with active-parameter tracking, including variadic parameter formatting, and registers Monaco’s signature-help provider.\n\nChecks:\n- go test ./...\n- GOOS=js GOARCH=wasm go test -exec=... ./...\n- go vet ./...\n- npm run lint\n- npm run build