### PR TITLE
Showcase standard library imports

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -18,11 +18,14 @@ const defaultCode = `// You can edit this code!
 // Click here and start typing.
 package main
 
-func foo() bool { return true }
+import "go/ast"
+
+func foo(node ast.Node) bool { return node != nil }
 
 func main() {
     var dummy bool
-    ok := foo()
+    var node ast.Node
+    ok := foo(node)
     if dummy {
         if ok {
             print(ok)


### PR DESCRIPTION
Updates the default example to import `go/ast` and use `ast.Node`, demonstrating standard-library type resolution in AST, CFG, SSA, and IDE features.

Checks:
- go test ./...
- npm run lint
- npm run build