### PR TITLE
Synchronize analysis views by source column

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,4 +1,4 @@
-import { KeyboardEvent, PointerEvent, useEffect, useRef, useState } from "react";
+import { KeyboardEvent, PointerEvent, useEffect, useMemo, useRef, useState } from "react";
 import { IPosition } from "monaco-editor";
 import { loadGoggleWasm, parseGoSource } from "../wasm/client.ts";
 import { ASTViewer } from "../viewers/ast/ASTViewer.tsx";
@@ -12,6 +12,11 @@ import {
   CFGFunction,
   SSAFunction,
 } from "../wasm/protocol.ts";
+import {
+  AnalysisPosition,
+  analysisPositionForEditorPosition,
+  editorPositionForAnalysisPosition,
+} from "../viewers/shared/lineMapping.ts";
 
 // We store the Go source and the last cursor position in local storage such that users will not lose their input.
 const defaultCode = `// You can edit this code!
@@ -134,11 +139,17 @@ export const App = () => {
     );
   }
 
-  const handleAnalysisLineSelect = (lineNumber: number) => {
+  const analysisPosition = useMemo<AnalysisPosition>(
+    () => analysisPositionForEditorPosition(src, srcPos),
+    [src, srcPos],
+  );
+
+  const handleAnalysisPositionSelect = (position: AnalysisPosition) => {
+    const editorPosition = editorPositionForAnalysisPosition(src, position);
     setSrcPos((current) =>
-      current.lineNumber === lineNumber
+      current.lineNumber === editorPosition.lineNumber && current.column === editorPosition.column
         ? current
-        : { lineNumber, column: 1 }
+        : editorPosition
     );
   };
 
@@ -232,8 +243,8 @@ export const App = () => {
           <section className="panel" aria-label="Control flow graph">
             <CFGViewer
               cfgs={cfgs}
-              sourceLine={srcPos.lineNumber}
-              onSourceLineSelect={handleAnalysisLineSelect}
+              sourcePosition={analysisPosition}
+              onSourcePositionSelect={handleAnalysisPositionSelect}
               theme={theme}
             />
           </section>
@@ -262,8 +273,8 @@ export const App = () => {
           <section className="panel" aria-label="Abstract syntax tree">
             <ASTViewer
               ast={ast}
-              sourceLine={srcPos.lineNumber}
-              onSourceLineSelect={handleAnalysisLineSelect}
+              sourcePosition={analysisPosition}
+              onSourcePositionSelect={handleAnalysisPositionSelect}
               theme={theme}
             />
           </section>
@@ -271,8 +282,8 @@ export const App = () => {
           <section className="panel" aria-label="Static single assignment form">
             <SSAViewer
               ssa={ssa}
-              sourceLine={srcPos.lineNumber}
-              onSourceLineSelect={handleAnalysisLineSelect}
+              sourcePosition={analysisPosition}
+              onSourcePositionSelect={handleAnalysisPositionSelect}
               theme={theme}
             />
           </section>

--- a/src/index.css
+++ b/src/index.css
@@ -888,6 +888,10 @@ a {
   background: var(--viz-accent-soft);
 }
 
+.ssa-graph-instruction--active {
+  box-shadow: inset 0 0 0 1px var(--viz-accent-border);
+}
+
 .ssa-graph-instruction--use {
   border-left-color: var(--viz-secondary);
   background: var(--viz-secondary-soft);
@@ -1126,6 +1130,10 @@ a {
 
 .ssa-instruction:hover {
   background: var(--viz-surface-hover);
+}
+
+.ssa-instruction--active {
+  box-shadow: inset 0 0 0 1px var(--viz-accent-border);
 }
 
 .ssa-instruction--definition {

--- a/src/viewers/ast/ASTTree.tsx
+++ b/src/viewers/ast/ASTTree.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { ASTNode } from "../../wasm/protocol.ts";
+import { AnalysisPosition } from "../shared/lineMapping.ts";
 
 interface ASTTreeProps {
   root: ASTNode;
-  sourceLine: number;
-  onSourceLineSelect: (line: number) => void;
+  sourcePosition: AnalysisPosition;
+  onSourcePositionSelect: (position: AnalysisPosition) => void;
 }
 
 interface ASTTreeNodeProps extends ASTTreeProps {
@@ -15,18 +16,22 @@ interface ASTTreeNodeProps extends ASTTreeProps {
   selectedPath: string | null;
 }
 
-const containsLine = (node: ASTNode, line: number) =>
-  node.range.start.line <= line && node.range.end.line >= line;
+const comparePosition = (left: AnalysisPosition, right: AnalysisPosition) =>
+  left.line === right.line ? left.column - right.column : left.line - right.line;
 
-const pathForLine = (
+const containsPosition = (node: ASTNode, position: AnalysisPosition) =>
+  comparePosition(node.range.start, position) <= 0 &&
+  comparePosition(position, node.range.end) <= 0;
+
+const pathForPosition = (
   node: ASTNode,
-  line: number,
+  position: AnalysisPosition,
   path = "root",
 ): string | null => {
-  if (!containsLine(node, line)) return null;
+  if (!containsPosition(node, position)) return null;
 
   for (const [childIndex, child] of (node.children ?? []).entries()) {
-    const childPath = pathForLine(child.node, line, `${path}.${childIndex}`);
+    const childPath = pathForPosition(child.node, position, `${path}.${childIndex}`);
     if (childPath !== null) return childPath;
   }
   return path;
@@ -69,7 +74,7 @@ const ASTTreeNode = (props: ASTTreeNodeProps) => {
         <button
           type="button"
           className="ast-tree__node"
-          onClick={() => props.onSourceLineSelect(props.node.range.start.line)}
+          onClick={() => props.onSourcePositionSelect(props.node.range.start)}
         >
           {props.label !== undefined && <span className="ast-tree__field">{props.label}</span>}
           <span className="ast-tree__type">{props.node.type}</span>
@@ -103,8 +108,8 @@ const ASTTreeNode = (props: ASTTreeNodeProps) => {
 export const ASTTree = (props: ASTTreeProps) => {
   const treeRef = useRef<HTMLDivElement>(null);
   const selectedPath = useMemo(
-    () => pathForLine(props.root, props.sourceLine),
-    [props.root, props.sourceLine],
+    () => pathForPosition(props.root, props.sourcePosition),
+    [props.root, props.sourcePosition],
   );
 
   useEffect(() => {

--- a/src/viewers/ast/ASTViewer.tsx
+++ b/src/viewers/ast/ASTViewer.tsx
@@ -7,15 +7,16 @@ import { formatAST } from "./format.ts";
 import { ASTTree } from "./ASTTree.tsx";
 import { AnalysisViewMode, ViewModeToggle } from "../shared/ViewModeToggle.tsx";
 import {
-  displayLineForSourceLine,
+  AnalysisPosition,
+  displayLineForSourcePosition,
   FormattedAnalysis,
-  sourceLineForDisplayLine,
+  sourcePositionForDisplayLine,
 } from "../shared/lineMapping.ts";
 
 interface ASTViewerProps {
   ast: ASTNode | string | null;
-  sourceLine: number;
-  onSourceLineSelect: (line: number) => void;
+  sourcePosition: AnalysisPosition;
+  onSourcePositionSelect: (position: AnalysisPosition) => void;
   theme: "light" | "dark";
 }
 
@@ -23,16 +24,16 @@ export const ASTViewer: React.FC<ASTViewerProps> = (props: ASTViewerProps) => {
   const [mode, setMode] = useState<AnalysisViewMode>("tree");
   const formatted = useMemo<FormattedAnalysis>(() => {
     if (props.ast === null) {
-      return { content: "AST unavailable", sourceLines: [] };
+      return { content: "AST unavailable", sourcePositions: [] };
     }
     if (typeof props.ast === "string") {
-      return { content: props.ast, sourceLines: [] };
+      return { content: props.ast, sourcePositions: [] };
     }
     return formatAST(props.ast);
   }, [props.ast]);
-  const displayLine = displayLineForSourceLine(
-    formatted.sourceLines,
-    props.sourceLine,
+  const displayLine = displayLineForSourcePosition(
+    formatted.sourcePositions,
+    props.sourcePosition,
   );
 
   return (
@@ -49,8 +50,8 @@ export const ASTViewer: React.FC<ASTViewerProps> = (props: ASTViewerProps) => {
             : (
               <ASTTree
                 root={props.ast}
-                sourceLine={props.sourceLine}
-                onSourceLineSelect={props.onSourceLineSelect}
+                sourcePosition={props.sourcePosition}
+                onSourcePositionSelect={props.onSourcePositionSelect}
               />
             )
         : (
@@ -58,12 +59,12 @@ export const ASTViewer: React.FC<ASTViewerProps> = (props: ASTViewerProps) => {
             content={formatted.content}
             line={displayLine}
             onCursorChange={(event) => {
-              const sourceLine = sourceLineForDisplayLine(
-                formatted.sourceLines,
+              const sourcePosition = sourcePositionForDisplayLine(
+                formatted.sourcePositions,
                 event.position.lineNumber,
               );
-              if (sourceLine !== undefined) {
-                props.onSourceLineSelect(sourceLine);
+              if (sourcePosition !== undefined) {
+                props.onSourcePositionSelect(sourcePosition);
               }
             }}
             readOnly={true}

--- a/src/viewers/ast/format.ts
+++ b/src/viewers/ast/format.ts
@@ -8,7 +8,7 @@ const formatRange = (range: SourceRange) =>
 
 export const formatAST = (root: ASTNode): FormattedAnalysis => {
   const lines: string[] = [];
-  const sourceLines: number[] = [];
+  const sourcePositions: FormattedAnalysis["sourcePositions"] = [];
 
   const visit = (node: ASTNode, depth: number, label?: string) => {
     const indentation = "  ".repeat(depth);
@@ -20,7 +20,7 @@ export const formatAST = (root: ASTNode): FormattedAnalysis => {
     lines.push(
       `${indentation}${prefix}${node.type} [${formatRange(node.range)}]${properties === "" ? "" : ` ${properties}`}`,
     );
-    sourceLines.push(node.range.start.line);
+    sourcePositions.push(node.range.start);
 
     for (const child of node.children ?? []) {
       const childLabel = child.index === undefined
@@ -33,6 +33,6 @@ export const formatAST = (root: ASTNode): FormattedAnalysis => {
   visit(root, 0);
   return {
     content: lines.join("\n"),
-    sourceLines,
+    sourcePositions,
   };
 };

--- a/src/viewers/cfg/CFGGraph.tsx
+++ b/src/viewers/cfg/CFGGraph.tsx
@@ -1,11 +1,12 @@
 import { useMemo, useState } from "react";
 import { CFGBlock, CFGFunction } from "../../wasm/protocol.ts";
 import { GraphViewport } from "../shared/GraphViewport.tsx";
+import { AnalysisPosition } from "../shared/lineMapping.ts";
 
 interface CFGGraphProps {
   functions: CFGFunction[];
-  sourceLine: number;
-  onSourceLineSelect: (line: number) => void;
+  sourcePosition: AnalysisPosition;
+  onSourcePositionSelect: (position: AnalysisPosition) => void;
 }
 
 interface PositionedBlock {
@@ -20,19 +21,43 @@ const COLUMN_GAP = 34;
 const ROW_GAP = 58;
 const CANVAS_PADDING = 24;
 
-const functionForLine = (functions: CFGFunction[], line: number) => {
+const comparePosition = (left: AnalysisPosition, right: AnalysisPosition) =>
+  left.line === right.line ? left.column - right.column : left.line - right.line;
+
+const rangeContainsPosition = (
+  start: AnalysisPosition,
+  end: AnalysisPosition,
+  position: AnalysisPosition,
+) => comparePosition(start, position) <= 0 && comparePosition(position, end) <= 0;
+
+const positionKey = (position: AnalysisPosition) => `${position.line}:${position.column}`;
+
+const functionForPosition = (functions: CFGFunction[], position: AnalysisPosition) => {
   const index = functions.findIndex((fn) =>
-    fn.range.start.line <= line && fn.range.end.line >= line
+    rangeContainsPosition(fn.range.start, fn.range.end, position)
   );
   return index < 0 ? 0 : index;
 };
 
-const blockLine = (block: CFGBlock, fallback: number) =>
-  block.nodes[0]?.range.start.line ?? block.statement?.range.start.line ?? fallback;
+const blockPosition = (block: CFGBlock, fallback: AnalysisPosition) =>
+  block.nodes[0]?.range.start ?? block.statement?.range.start ?? fallback;
 
-const blockContainsLine = (block: CFGBlock, line: number) => {
-  const nodes = [block.statement, ...block.nodes].filter((node) => node !== undefined);
-  return nodes.some((node) => node.range.start.line <= line && node.range.end.line >= line);
+const blockForPosition = (fn: CFGFunction, position: AnalysisPosition) => {
+  let closest: { index: number; width: number; live: boolean } | null = null;
+  for (const block of fn.blocks) {
+    for (const node of [...block.nodes, block.statement].filter((item) => item !== undefined)) {
+      if (!rangeContainsPosition(node.range.start, node.range.end, position)) continue;
+      const width = node.range.end.offset - node.range.start.offset;
+      if (
+        closest === null ||
+        (block.live && !closest.live) ||
+        (block.live === closest.live && width < closest.width)
+      ) {
+        closest = { index: block.index, width, live: block.live };
+      }
+    }
+  }
+  return closest?.index;
 };
 
 const layoutBlocks = (fn: CFGFunction) => {
@@ -89,12 +114,13 @@ const layoutBlocks = (fn: CFGFunction) => {
 
 export const CFGGraph = (props: CFGGraphProps) => {
   const [selection, setSelection] = useState(() => ({
-    index: functionForLine(props.functions, props.sourceLine),
-    sourceLine: props.sourceLine,
+    index: functionForPosition(props.functions, props.sourcePosition),
+    sourcePosition: positionKey(props.sourcePosition),
   }));
-  const selectedFunction = selection.sourceLine === props.sourceLine
+  const currentPositionKey = positionKey(props.sourcePosition);
+  const selectedFunction = selection.sourcePosition === currentPositionKey
     ? selection.index
-    : functionForLine(props.functions, props.sourceLine);
+    : functionForPosition(props.functions, props.sourcePosition);
   const functionIndex = Math.min(selectedFunction, Math.max(0, props.functions.length - 1));
   const fn = props.functions[functionIndex];
   const layout = useMemo(() => fn === undefined ? null : layoutBlocks(fn), [fn]);
@@ -103,6 +129,7 @@ export const CFGGraph = (props: CFGGraphProps) => {
   if (fn === undefined || layout === null) {
     return <div className="analysis-placeholder">Add a function to see its control flow.</div>;
   }
+  const activeBlock = blockForPosition(fn, props.sourcePosition);
 
   return (
     <div className="analysis-visual analysis-visual--with-toolbar">
@@ -113,7 +140,7 @@ export const CFGGraph = (props: CFGGraphProps) => {
             value={functionIndex}
             onChange={(event) => setSelection({
               index: Number(event.target.value),
-              sourceLine: props.sourceLine,
+              sourcePosition: currentPositionKey,
             })}
           >
             {props.functions.map((candidate, index) => (
@@ -159,14 +186,14 @@ export const CFGGraph = (props: CFGGraphProps) => {
           {layout.positioned.map(({ block, x, y }) => {
             const source = block.nodes.map((node) => node.source).join("; ") ||
               block.statement?.source || "Empty block";
-            const active = blockContainsLine(block, props.sourceLine);
+            const active = block.index === activeBlock;
             return (
               <button
                 type="button"
                 key={block.index}
                 className={`cfg-card${block.live ? "" : " cfg-card--unreachable"}${active ? " cfg-card--active" : ""}`}
                 style={{ left: x, top: y, width: CARD_WIDTH, height: CARD_HEIGHT }}
-                onClick={() => props.onSourceLineSelect(blockLine(block, fn.range.start.line))}
+                onClick={() => props.onSourcePositionSelect(blockPosition(block, fn.range.start))}
               >
                 <span className="cfg-card__header">
                   <strong>B{block.index}</strong>

--- a/src/viewers/cfg/CFGViewer.tsx
+++ b/src/viewers/cfg/CFGViewer.tsx
@@ -7,15 +7,16 @@ import { formatCFGs } from "./format.ts";
 import { CFGGraph } from "./CFGGraph.tsx";
 import { AnalysisViewMode, ViewModeToggle } from "../shared/ViewModeToggle.tsx";
 import {
-  displayLineForSourceLine,
+  AnalysisPosition,
+  displayLineForSourcePosition,
   FormattedAnalysis,
-  sourceLineForDisplayLine,
+  sourcePositionForDisplayLine,
 } from "../shared/lineMapping.ts";
 
 interface CFGViewerProps {
   cfgs: CFGFunction[] | string | null;
-  sourceLine: number;
-  onSourceLineSelect: (line: number) => void;
+  sourcePosition: AnalysisPosition;
+  onSourcePositionSelect: (position: AnalysisPosition) => void;
   theme: "light" | "dark";
 }
 
@@ -25,17 +26,17 @@ export const CFGViewer: React.FC<CFGViewerProps> = (props: CFGViewerProps) => {
     if (props.cfgs === null) {
       return {
         content: "CFG unavailable, try adding function declarations to the source",
-        sourceLines: [],
+        sourcePositions: [],
       };
     }
     if (typeof props.cfgs === "string") {
-      return { content: props.cfgs, sourceLines: [] };
+      return { content: props.cfgs, sourcePositions: [] };
     }
     return formatCFGs(props.cfgs);
   }, [props.cfgs]);
-  const displayLine = displayLineForSourceLine(
-    formatted.sourceLines,
-    props.sourceLine,
+  const displayLine = displayLineForSourcePosition(
+    formatted.sourcePositions,
+    props.sourcePosition,
   );
 
   return (
@@ -52,8 +53,8 @@ export const CFGViewer: React.FC<CFGViewerProps> = (props: CFGViewerProps) => {
             : (
               <CFGGraph
                 functions={props.cfgs}
-                sourceLine={props.sourceLine}
-                onSourceLineSelect={props.onSourceLineSelect}
+                sourcePosition={props.sourcePosition}
+                onSourcePositionSelect={props.onSourcePositionSelect}
               />
             )
         : (
@@ -61,12 +62,12 @@ export const CFGViewer: React.FC<CFGViewerProps> = (props: CFGViewerProps) => {
             content={formatted.content}
             line={displayLine}
             onCursorChange={(event) => {
-              const sourceLine = sourceLineForDisplayLine(
-                formatted.sourceLines,
+              const sourcePosition = sourcePositionForDisplayLine(
+                formatted.sourcePositions,
                 event.position.lineNumber,
               );
-              if (sourceLine !== undefined) {
-                props.onSourceLineSelect(sourceLine);
+              if (sourcePosition !== undefined) {
+                props.onSourcePositionSelect(sourcePosition);
               }
             }}
             readOnly={true}

--- a/src/viewers/cfg/format.ts
+++ b/src/viewers/cfg/format.ts
@@ -1,5 +1,5 @@
 import { CFGFunction, SourceRange } from "../../wasm/protocol.ts";
-import { FormattedAnalysis } from "../shared/lineMapping.ts";
+import { AnalysisPosition, FormattedAnalysis } from "../shared/lineMapping.ts";
 
 const formatPosition = (line: number, column: number) => `${line}:${column}`;
 
@@ -10,16 +10,21 @@ export const formatCFGs = (functions: CFGFunction[]): FormattedAnalysis => {
   if (functions.length === 0) {
     return {
       content: "CFG unavailable, try adding function declarations to the source",
-      sourceLines: [],
+      sourcePositions: [],
     };
   }
 
   const lines: string[] = [];
-  const sourceLines: Array<number | null> = [];
-  const append = (text: string, sourceLine: number | null) => {
+  const sourcePositions: FormattedAnalysis["sourcePositions"] = [];
+  const append = (text: string, sourcePosition: AnalysisPosition | null) => {
     for (const [index, part] of text.split("\n").entries()) {
       lines.push(index === 0 ? part : `  ${part}`);
-      sourceLines.push(sourceLine === null ? null : sourceLine + index);
+      sourcePositions.push(sourcePosition === null
+        ? null
+        : {
+          line: sourcePosition.line + index,
+          column: index === 0 ? sourcePosition.column : 1,
+        });
     }
   };
 
@@ -29,38 +34,38 @@ export const formatCFGs = (functions: CFGFunction[]): FormattedAnalysis => {
     }
     append(
       `func ${fn.name} [${formatRange(fn.range)}]${fn.noReturn ? " (no return)" : ""}`,
-      fn.range.start.line,
+      fn.range.start,
     );
     for (const block of fn.blocks) {
-      const blockLine = block.statement?.range.start.line ??
-        block.nodes[0]?.range.start.line ??
-        fn.range.start.line;
+      const blockPosition = block.statement?.range.start ??
+        block.nodes[0]?.range.start ??
+        fn.range.start;
       append("", null);
       append(
         `block ${block.index} (${block.kind})${block.live ? "" : " [unreachable]"}`,
-        blockLine,
+        blockPosition,
       );
       if (block.statement !== undefined) {
         append(
           `  control: ${block.statement.type} [${formatRange(block.statement.range)}]`,
-          block.statement.range.start.line,
+          block.statement.range.start,
         );
       }
       for (const node of block.nodes) {
         append(
           `  ${node.type} [${formatRange(node.range)}] ${node.source}`,
-          node.range.start.line,
+          node.range.start,
         );
       }
       append(
         `  successors: ${block.successors.length === 0 ? "none" : block.successors.join(", ")}`,
-        blockLine,
+        blockPosition,
       );
     }
   });
 
   return {
     content: lines.join("\n"),
-    sourceLines,
+    sourcePositions,
   };
 };

--- a/src/viewers/shared/lineMapping.ts
+++ b/src/viewers/shared/lineMapping.ts
@@ -1,24 +1,70 @@
-export interface FormattedAnalysis {
-  content: string;
-  sourceLines: Array<number | null>;
+export interface AnalysisPosition {
+  line: number;
+  column: number;
 }
 
-export const sourceLineForDisplayLine = (
-  sourceLines: Array<number | null>,
+export interface EditorPosition {
+  lineNumber: number;
+  column: number;
+}
+
+const utf8Encoder = new TextEncoder();
+
+const sourceLine = (source: string, line: number) =>
+  (source.split("\n")[line - 1] ?? "").replace(/\r$/, "");
+
+export const analysisPositionForEditorPosition = (
+  source: string,
+  position: EditorPosition,
+): AnalysisPosition => {
+  const prefix = sourceLine(source, position.lineNumber).slice(0, position.column - 1);
+  return {
+    line: position.lineNumber,
+    column: utf8Encoder.encode(prefix).length + 1,
+  };
+};
+
+export const editorPositionForAnalysisPosition = (
+  source: string,
+  position: AnalysisPosition,
+): EditorPosition => {
+  const line = sourceLine(source, position.line);
+  const targetByteOffset = Math.max(0, position.column - 1);
+  let byteOffset = 0;
+  let utf16Offset = 0;
+  for (const character of line) {
+    const characterBytes = utf8Encoder.encode(character).length;
+    if (byteOffset + characterBytes > targetByteOffset) break;
+    byteOffset += characterBytes;
+    utf16Offset += character.length;
+  }
+  return {
+    lineNumber: position.line,
+    column: utf16Offset + 1,
+  };
+};
+
+export interface FormattedAnalysis {
+  content: string;
+  sourcePositions: Array<AnalysisPosition | null>;
+}
+
+export const sourcePositionForDisplayLine = (
+  sourcePositions: Array<AnalysisPosition | null>,
   displayLine: number,
-): number | undefined => {
+): AnalysisPosition | undefined => {
   const index = displayLine - 1;
-  const direct = sourceLines[index];
+  const direct = sourcePositions[index];
   if (direct !== undefined && direct !== null) {
     return direct;
   }
 
-  for (let distance = 1; distance < sourceLines.length; distance++) {
-    const before = sourceLines[index - distance];
+  for (let distance = 1; distance < sourcePositions.length; distance++) {
+    const before = sourcePositions[index - distance];
     if (before !== undefined && before !== null) {
       return before;
     }
-    const after = sourceLines[index + distance];
+    const after = sourcePositions[index + distance];
     if (after !== undefined && after !== null) {
       return after;
     }
@@ -27,21 +73,27 @@ export const sourceLineForDisplayLine = (
   return undefined;
 };
 
-export const displayLineForSourceLine = (
-  sourceLines: Array<number | null>,
-  sourceLine: number,
+export const displayLineForSourcePosition = (
+  sourcePositions: Array<AnalysisPosition | null>,
+  sourcePosition: AnalysisPosition,
 ): number | undefined => {
   let closestIndex: number | undefined;
-  let closestDistance = Number.POSITIVE_INFINITY;
+  let closestLineDistance = Number.POSITIVE_INFINITY;
+  let closestColumnDistance = Number.POSITIVE_INFINITY;
 
-  sourceLines.forEach((candidate, index) => {
+  sourcePositions.forEach((candidate, index) => {
     if (candidate === null) {
       return;
     }
-    const distance = Math.abs(candidate - sourceLine);
-    if (distance < closestDistance) {
+    const lineDistance = Math.abs(candidate.line - sourcePosition.line);
+    const columnDistance = Math.abs(candidate.column - sourcePosition.column);
+    if (
+      lineDistance < closestLineDistance ||
+      (lineDistance === closestLineDistance && columnDistance < closestColumnDistance)
+    ) {
       closestIndex = index;
-      closestDistance = distance;
+      closestLineDistance = lineDistance;
+      closestColumnDistance = columnDistance;
     }
   });
 

--- a/src/viewers/ssa/SSABlocks.tsx
+++ b/src/viewers/ssa/SSABlocks.tsx
@@ -1,32 +1,17 @@
-import { KeyboardEvent, useMemo, useState } from "react";
+import { KeyboardEvent, useEffect, useMemo, useRef, useState } from "react";
 import { SSAFunction, SSAInstruction, SSAValue } from "../../wasm/protocol.ts";
+import { AnalysisPosition } from "../shared/lineMapping.ts";
+import {
+  analysisPositionKey,
+  closestInstructionForPosition,
+  functionForPosition,
+} from "./position.ts";
 
 interface SSABlocksProps {
   functions: SSAFunction[];
-  sourceLine: number;
-  onSourceLineSelect: (line: number) => void;
+  sourcePosition: AnalysisPosition;
+  onSourcePositionSelect: (position: AnalysisPosition) => void;
 }
-
-const functionForLine = (functions: SSAFunction[], line: number) => {
-  let closestIndex = 0;
-  let closestDistance = Number.POSITIVE_INFINITY;
-  functions.forEach((fn, index) => {
-    const positions = [
-      fn.position.line,
-      ...fn.blocks.flatMap((block) =>
-        block.instructions.flatMap((instruction) =>
-          instruction.position === undefined ? [] : [instruction.position.line]
-        )
-      ),
-    ];
-    const distance = Math.min(...positions.map((position) => Math.abs(position - line)));
-    if (distance < closestDistance) {
-      closestIndex = index;
-      closestDistance = distance;
-    }
-  });
-  return closestIndex;
-};
 
 const ValueChip = (props: {
   value: SSAValue;
@@ -52,16 +37,25 @@ const instructionHasValue = (instruction: SSAInstruction, value: string) =>
   instruction.operands.some((operand) => operand.name === value);
 
 export const SSABlocks = (props: SSABlocksProps) => {
+  const scrollRef = useRef<HTMLDivElement>(null);
   const [selection, setSelection] = useState(() => ({
-    index: functionForLine(props.functions, props.sourceLine),
-    sourceLine: props.sourceLine,
+    index: functionForPosition(props.functions, props.sourcePosition),
+    sourcePosition: analysisPositionKey(props.sourcePosition),
   }));
   const [selectedValue, setSelectedValue] = useState<string | null>(null);
-  const selectedFunction = selection.sourceLine === props.sourceLine
+  const currentPositionKey = analysisPositionKey(props.sourcePosition);
+  const selectedFunction = selection.sourcePosition === currentPositionKey
     ? selection.index
-    : functionForLine(props.functions, props.sourceLine);
+    : functionForPosition(props.functions, props.sourcePosition);
   const functionIndex = Math.min(selectedFunction, Math.max(0, props.functions.length - 1));
   const fn = props.functions[functionIndex];
+  const closestInstruction = useMemo(
+    () => fn === undefined ? null : closestInstructionForPosition(fn, props.sourcePosition),
+    [fn, props.sourcePosition],
+  );
+  const closestInstructionKey = closestInstruction === null
+    ? null
+    : `${closestInstruction.blockIndex}:${closestInstruction.instruction.index}`;
   const availableValues = useMemo(() => new Set([
     ...(fn?.parameters.map((parameter) => parameter.name) ?? []),
     ...(fn?.blocks.flatMap((block) =>
@@ -85,12 +79,18 @@ export const SSABlocks = (props: SSABlocksProps) => {
     };
   }, [fn, focusedValue]);
 
+  useEffect(() => {
+    scrollRef.current
+      ?.querySelector<HTMLElement>('[data-source-selected="true"]')
+      ?.scrollIntoView({ block: "nearest", inline: "nearest" });
+  }, [closestInstructionKey]);
+
   if (fn === undefined) {
     return <div className="analysis-placeholder">Add a function to inspect its SSA form.</div>;
   }
 
   const selectInstruction = (instruction: SSAInstruction) => {
-    props.onSourceLineSelect(instruction.position?.line ?? fn.position.line);
+    props.onSourcePositionSelect(instruction.position ?? fn.position);
   };
   const selectInstructionWithKeyboard = (
     event: KeyboardEvent<HTMLDivElement>,
@@ -111,7 +111,7 @@ export const SSABlocks = (props: SSABlocksProps) => {
             onChange={(event) => {
               setSelection({
                 index: Number(event.target.value),
-                sourceLine: props.sourceLine,
+                sourcePosition: currentPositionKey,
               });
               setSelectedValue(null);
             }}
@@ -125,7 +125,7 @@ export const SSABlocks = (props: SSABlocksProps) => {
         </label>
         <span className="analysis-toolbar__meta">{fn.blocks.length} blocks</span>
       </div>
-      <div className="ssa-scroll">
+      <div ref={scrollRef} className="ssa-scroll">
         <div className="ssa-signature">
           <span className="ssa-signature__name">{fn.name}</span>
           <code>{fn.signature}</code>
@@ -151,9 +151,7 @@ export const SSABlocks = (props: SSABlocksProps) => {
 
         <div className="ssa-blocks">
           {fn.blocks.map((block) => {
-            const active = block.instructions.some((instruction) =>
-              instruction.position?.line === props.sourceLine
-            );
+            const active = closestInstruction?.blockIndex === block.index;
             return (
               <section
                 key={block.index}
@@ -171,10 +169,13 @@ export const SSABlocks = (props: SSABlocksProps) => {
                       operand.name === focusedValue
                     );
                     const dimmed = focusedValue !== null && !instructionHasValue(instruction, focusedValue);
+                    const instructionActive = closestInstruction?.blockIndex === block.index &&
+                      closestInstruction.instruction.index === instruction.index;
                     return (
                       <div
                         key={instruction.index}
-                        className={`ssa-instruction${definition ? " ssa-instruction--definition" : ""}${use ? " ssa-instruction--use" : ""}${dimmed ? " ssa-instruction--dimmed" : ""}`}
+                        className={`ssa-instruction${instructionActive ? " ssa-instruction--active" : ""}${definition ? " ssa-instruction--definition" : ""}${use ? " ssa-instruction--use" : ""}${dimmed ? " ssa-instruction--dimmed" : ""}`}
+                        data-source-selected={instructionActive ? "true" : undefined}
                         role="button"
                         tabIndex={0}
                         onClick={() => selectInstruction(instruction)}

--- a/src/viewers/ssa/SSAGraph.tsx
+++ b/src/viewers/ssa/SSAGraph.tsx
@@ -1,11 +1,17 @@
 import { useMemo, useState } from "react";
 import { SSABlock, SSAFunction } from "../../wasm/protocol.ts";
 import { GraphViewport } from "../shared/GraphViewport.tsx";
+import { AnalysisPosition } from "../shared/lineMapping.ts";
+import {
+  analysisPositionKey,
+  closestInstructionForPosition,
+  functionForPosition,
+} from "./position.ts";
 
 interface SSAGraphProps {
   functions: SSAFunction[];
-  sourceLine: number;
-  onSourceLineSelect: (line: number) => void;
+  sourcePosition: AnalysisPosition;
+  onSourcePositionSelect: (position: AnalysisPosition) => void;
 }
 
 interface PositionedBlock {
@@ -20,27 +26,6 @@ const COLUMN_GAP = 42;
 const ROW_GAP = 66;
 const CANVAS_PADDING = 28;
 const VISIBLE_INSTRUCTIONS = 4;
-
-const functionForLine = (functions: SSAFunction[], line: number) => {
-  let closestIndex = 0;
-  let closestDistance = Number.POSITIVE_INFINITY;
-  functions.forEach((fn, index) => {
-    const lines = [
-      fn.position.line,
-      ...fn.blocks.flatMap((block) =>
-        block.instructions.flatMap((instruction) =>
-          instruction.position === undefined ? [] : [instruction.position.line]
-        )
-      ),
-    ];
-    const distance = Math.min(...lines.map((candidate) => Math.abs(candidate - line)));
-    if (distance < closestDistance) {
-      closestIndex = index;
-      closestDistance = distance;
-    }
-  });
-  return closestIndex;
-};
 
 const layoutBlocks = (fn: SSAFunction) => {
   const byIndex = new Map(fn.blocks.map((block) => [block.index, block]));
@@ -127,16 +112,21 @@ const dataEdgesForValue = (fn: SSAFunction, value: string | null) => {
 
 export const SSAGraph = (props: SSAGraphProps) => {
   const [selection, setSelection] = useState(() => ({
-    index: functionForLine(props.functions, props.sourceLine),
-    sourceLine: props.sourceLine,
+    index: functionForPosition(props.functions, props.sourcePosition),
+    sourcePosition: analysisPositionKey(props.sourcePosition),
   }));
   const [selectedValue, setSelectedValue] = useState<string | null>(null);
-  const selectedFunction = selection.sourceLine === props.sourceLine
+  const currentPositionKey = analysisPositionKey(props.sourcePosition);
+  const selectedFunction = selection.sourcePosition === currentPositionKey
     ? selection.index
-    : functionForLine(props.functions, props.sourceLine);
+    : functionForPosition(props.functions, props.sourcePosition);
   const functionIndex = Math.min(selectedFunction, Math.max(0, props.functions.length - 1));
   const fn = props.functions[functionIndex];
   const layout = useMemo(() => fn === undefined ? null : layoutBlocks(fn), [fn]);
+  const closestInstruction = useMemo(
+    () => fn === undefined ? null : closestInstructionForPosition(fn, props.sourcePosition),
+    [fn, props.sourcePosition],
+  );
 
   if (fn === undefined || layout === null) {
     return <div className="analysis-placeholder">Add a function to graph its SSA form.</div>;
@@ -163,7 +153,7 @@ export const SSAGraph = (props: SSAGraphProps) => {
             onChange={(event) => {
               setSelection({
                 index: Number(event.target.value),
-                sourceLine: props.sourceLine,
+                sourcePosition: currentPositionKey,
               });
               setSelectedValue(null);
             }}
@@ -232,12 +222,18 @@ export const SSAGraph = (props: SSAGraphProps) => {
             })}
           </svg>
           {layout.positioned.map(({ block, x, y }) => {
-            const active = block.instructions.some((instruction) =>
-              instruction.position?.line === props.sourceLine
-            );
-            const firstLine = block.instructions.find((instruction) =>
+            const active = closestInstruction?.blockIndex === block.index;
+            const activeInstruction = active ? closestInstruction?.instruction : undefined;
+            const visibleInstructions = block.instructions.slice(0, VISIBLE_INSTRUCTIONS);
+            if (
+              activeInstruction !== undefined &&
+              !visibleInstructions.some((instruction) => instruction.index === activeInstruction.index)
+            ) {
+              visibleInstructions[VISIBLE_INSTRUCTIONS - 1] = activeInstruction;
+            }
+            const firstPosition = block.instructions.find((instruction) =>
               instruction.position !== undefined
-            )?.position?.line ?? fn.position.line;
+            )?.position ?? fn.position;
             return (
               <section
                 key={block.index}
@@ -247,22 +243,24 @@ export const SSAGraph = (props: SSAGraphProps) => {
                 <button
                   type="button"
                   className="ssa-graph-card__header"
-                  onClick={() => props.onSourceLineSelect(firstLine)}
+                  onClick={() => props.onSourcePositionSelect(firstPosition)}
                 >
                   <strong>B{block.index}</strong>
                   <span>{block.comment ?? "block"}</span>
                   <span>{block.successors.length === 0 ? "exit" : `→ ${block.successors.map((successor) => `B${successor}`).join(", ")}`}</span>
                 </button>
                 <div className="ssa-graph-card__instructions">
-                  {block.instructions.slice(0, VISIBLE_INSTRUCTIONS).map((instruction) => {
+                  {visibleInstructions.map((instruction) => {
                     const definition = focusedValue !== null && instruction.result?.name === focusedValue;
                     const use = focusedValue !== null && instruction.operands.some((operand) =>
                       operand.name === focusedValue
                     );
+                    const instructionActive = closestInstruction?.blockIndex === block.index &&
+                      closestInstruction.instruction.index === instruction.index;
                     return (
                       <div
                         key={instruction.index}
-                        className={`ssa-graph-instruction${definition ? " ssa-graph-instruction--definition" : ""}${use ? " ssa-graph-instruction--use" : ""}`}
+                        className={`ssa-graph-instruction${instructionActive ? " ssa-graph-instruction--active" : ""}${definition ? " ssa-graph-instruction--definition" : ""}${use ? " ssa-graph-instruction--use" : ""}`}
                       >
                         {instruction.result === undefined
                           ? <span className="ssa-graph-instruction__empty">·</span>
@@ -280,8 +278,8 @@ export const SSAGraph = (props: SSAGraphProps) => {
                           type="button"
                           className="ssa-graph-instruction__text"
                           title={instruction.text}
-                          onClick={() => props.onSourceLineSelect(
-                            instruction.position?.line ?? fn.position.line
+                          onClick={() => props.onSourcePositionSelect(
+                            instruction.position ?? fn.position
                           )}
                         >
                           <span>{instruction.opcode}</span>

--- a/src/viewers/ssa/SSAViewer.tsx
+++ b/src/viewers/ssa/SSAViewer.tsx
@@ -8,15 +8,16 @@ import { SSABlocks } from "./SSABlocks.tsx";
 import { SSAGraph } from "./SSAGraph.tsx";
 import { AnalysisViewMode, ViewModeToggle } from "../shared/ViewModeToggle.tsx";
 import {
-  displayLineForSourceLine,
+  AnalysisPosition,
+  displayLineForSourcePosition,
   FormattedAnalysis,
-  sourceLineForDisplayLine,
+  sourcePositionForDisplayLine,
 } from "../shared/lineMapping.ts";
 
 interface SSAViewerProps {
   ssa: SSAFunction[] | string | null;
-  sourceLine: number;
-  onSourceLineSelect: (line: number) => void;
+  sourcePosition: AnalysisPosition;
+  onSourcePositionSelect: (position: AnalysisPosition) => void;
   theme: "light" | "dark";
 }
 
@@ -26,17 +27,17 @@ export const SSAViewer: React.FC<SSAViewerProps> = (props: SSAViewerProps) => {
     if (props.ssa === null) {
       return {
         content: "SSA unavailable, try adding function declarations to the source",
-        sourceLines: [],
+        sourcePositions: [],
       };
     }
     if (typeof props.ssa === "string") {
-      return { content: props.ssa, sourceLines: [] };
+      return { content: props.ssa, sourcePositions: [] };
     }
     return formatSSA(props.ssa);
   }, [props.ssa]);
-  const displayLine = displayLineForSourceLine(
-    formatted.sourceLines,
-    props.sourceLine,
+  const displayLine = displayLineForSourcePosition(
+    formatted.sourcePositions,
+    props.sourcePosition,
   );
 
   return (
@@ -58,8 +59,8 @@ export const SSAViewer: React.FC<SSAViewerProps> = (props: SSAViewerProps) => {
             : (
               <SSABlocks
                 functions={props.ssa}
-                sourceLine={props.sourceLine}
-                onSourceLineSelect={props.onSourceLineSelect}
+                sourcePosition={props.sourcePosition}
+                onSourcePositionSelect={props.onSourcePositionSelect}
               />
             )
         : mode === "graph"
@@ -70,8 +71,8 @@ export const SSAViewer: React.FC<SSAViewerProps> = (props: SSAViewerProps) => {
               : (
                 <SSAGraph
                   functions={props.ssa}
-                  sourceLine={props.sourceLine}
-                  onSourceLineSelect={props.onSourceLineSelect}
+                  sourcePosition={props.sourcePosition}
+                  onSourcePositionSelect={props.onSourcePositionSelect}
                 />
               )
         : (
@@ -79,12 +80,12 @@ export const SSAViewer: React.FC<SSAViewerProps> = (props: SSAViewerProps) => {
             content={formatted.content}
             line={displayLine}
             onCursorChange={(event) => {
-              const sourceLine = sourceLineForDisplayLine(
-                formatted.sourceLines,
+              const sourcePosition = sourcePositionForDisplayLine(
+                formatted.sourcePositions,
                 event.position.lineNumber,
               );
-              if (sourceLine !== undefined) {
-                props.onSourceLineSelect(sourceLine);
+              if (sourcePosition !== undefined) {
+                props.onSourcePositionSelect(sourcePosition);
               }
             }}
             readOnly={true}

--- a/src/viewers/ssa/format.ts
+++ b/src/viewers/ssa/format.ts
@@ -1,5 +1,5 @@
 import { SourcePosition, SSAFunction } from "../../wasm/protocol.ts";
-import { FormattedAnalysis } from "../shared/lineMapping.ts";
+import { AnalysisPosition, FormattedAnalysis } from "../shared/lineMapping.ts";
 
 const formatPosition = (position: SourcePosition) =>
   `${position.line}:${position.column}`;
@@ -8,15 +8,15 @@ export const formatSSA = (functions: SSAFunction[]): FormattedAnalysis => {
   if (functions.length === 0) {
     return {
       content: "SSA unavailable, try adding function declarations to the source",
-      sourceLines: [],
+      sourcePositions: [],
     };
   }
 
   const lines: string[] = [];
-  const sourceLines: Array<number | null> = [];
-  const append = (text: string, sourceLine: number | null) => {
+  const sourcePositions: FormattedAnalysis["sourcePositions"] = [];
+  const append = (text: string, sourcePosition: AnalysisPosition | null) => {
     lines.push(text);
-    sourceLines.push(sourceLine);
+    sourcePositions.push(sourcePosition);
   };
 
   functions.forEach((fn, functionIndex) => {
@@ -28,7 +28,7 @@ export const formatSSA = (functions: SSAFunction[]): FormattedAnalysis => {
       : ` ${fn.signature}`;
     append(
       `func ${fn.name}${signature} [${formatPosition(fn.position)}]`,
-      fn.position.line,
+      fn.position,
     );
 
     for (const block of fn.blocks) {
@@ -41,13 +41,13 @@ export const formatSSA = (functions: SSAFunction[]): FormattedAnalysis => {
       const successors = block.successors.length === 0
         ? "none"
         : block.successors.join(", ");
-      const blockLine = block.instructions.find((instruction) =>
+      const blockPosition = block.instructions.find((instruction) =>
         instruction.position !== undefined
-      )?.position?.line ?? fn.position.line;
+      )?.position ?? fn.position;
       append("", null);
       append(
         `block ${block.index}${comment}  predecessors: ${predecessors}  successors: ${successors}`,
-        blockLine,
+        blockPosition,
       );
 
       for (const instruction of block.instructions) {
@@ -61,7 +61,7 @@ export const formatSSA = (functions: SSAFunction[]): FormattedAnalysis => {
           : `  // ${instruction.result.type}`;
         append(
           `  ${instruction.index}: ${result}${instruction.text}${resultType}`,
-          instruction.position?.line ?? blockLine,
+          instruction.position ?? blockPosition,
         );
       }
     }
@@ -69,6 +69,6 @@ export const formatSSA = (functions: SSAFunction[]): FormattedAnalysis => {
 
   return {
     content: lines.join("\n"),
-    sourceLines,
+    sourcePositions,
   };
 };

--- a/src/viewers/ssa/position.ts
+++ b/src/viewers/ssa/position.ts
@@ -1,0 +1,69 @@
+import { SSAFunction, SSAInstruction } from "../../wasm/protocol.ts";
+import { AnalysisPosition } from "../shared/lineMapping.ts";
+
+export const analysisPositionKey = (position: AnalysisPosition) =>
+  `${position.line}:${position.column}`;
+
+const positionDistance = (
+  candidate: AnalysisPosition,
+  target: AnalysisPosition,
+) => ({
+  line: Math.abs(candidate.line - target.line),
+  column: Math.abs(candidate.column - target.column),
+});
+
+const isCloser = (
+  candidate: ReturnType<typeof positionDistance>,
+  closest: ReturnType<typeof positionDistance>,
+) => candidate.line < closest.line ||
+  (candidate.line === closest.line && candidate.column < closest.column);
+
+export const functionForPosition = (
+  functions: SSAFunction[],
+  position: AnalysisPosition,
+) => {
+  let closestIndex = 0;
+  let closestDistance = { line: Number.POSITIVE_INFINITY, column: Number.POSITIVE_INFINITY };
+  functions.forEach((fn, index) => {
+    const positions = [
+      fn.position,
+      ...fn.blocks.flatMap((block) =>
+        block.instructions.flatMap((instruction) =>
+          instruction.position === undefined ? [] : [instruction.position]
+        )
+      ),
+    ];
+    const distance = positions
+      .map((candidate) => positionDistance(candidate, position))
+      .reduce((closest, candidate) => isCloser(candidate, closest) ? candidate : closest);
+    if (isCloser(distance, closestDistance)) {
+      closestIndex = index;
+      closestDistance = distance;
+    }
+  });
+  return closestIndex;
+};
+
+export interface ClosestSSAInstruction {
+  blockIndex: number;
+  instruction: SSAInstruction;
+}
+
+export const closestInstructionForPosition = (
+  fn: SSAFunction,
+  position: AnalysisPosition,
+): ClosestSSAInstruction | null => {
+  let closest: ClosestSSAInstruction | null = null;
+  let closestDistance = { line: Number.POSITIVE_INFINITY, column: Number.POSITIVE_INFINITY };
+  for (const block of fn.blocks) {
+    for (const instruction of block.instructions) {
+      if (instruction.position === undefined) continue;
+      const distance = positionDistance(instruction.position, position);
+      if (isCloser(distance, closestDistance)) {
+        closest = { blockIndex: block.index, instruction };
+        closestDistance = distance;
+      }
+    }
+  }
+  return closest;
+};


### PR DESCRIPTION
## Summary
- carry full source positions through AST, CFG, SSA, and text fallbacks
- select the deepest AST node, matching CFG block, and nearest SSA instruction by line and column
- convert between Go UTF-8 byte columns and Monaco UTF-16 columns for Unicode-safe synchronization
- scroll selected SSA instructions into view

## Testing
- `npm run lint`
- `npm run build`
- `git diff --check`